### PR TITLE
BAU: Fix the Gradle image tag being used in the Concourse pipeline

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -52,6 +52,7 @@ jobs:
           type: registry-image
           source:
             repository: gradle
+            tag: 6.8.3-jdk15
         inputs:
           - name: di-auth-stub-relying-party
         outputs:


### PR DESCRIPTION
## What

Fix the Gradle version being used in the pipeline

## Why

Pipeline is failing.