### PR TITLE
BAU - Upgrade to java 16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,16 +9,13 @@ repositories {
 }
 
 dependencies {
-    compile(
-        "com.sparkjava:spark-core:2.9.3",
+    implementation "com.sparkjava:spark-core:2.9.3",
         "com.sparkjava:spark-template-mustache:2.7.1",
         "com.nimbusds:oauth2-oidc-sdk:9.3.1",
         "org.slf4j:slf4j-simple:1.7.2"
-    )
 
-    testCompile(
-        group: 'junit', name: 'junit', version: '4.12'
-    )
+    testImplementation "junit:junit:4.12"
+
 }
 
 mainClassName = 'uk.gov.di.App'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/manifest.yml
+++ b/manifest.yml
@@ -7,7 +7,7 @@ applications:
     command: cd di-auth-stub-relying-party && bin/di-auth-stub-relying-party
     env:
       JAVA_HOME: "../.java-buildpack/open_jdk_jre"
-      JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 15.+}}'
+      JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 16.+}}'
       CLIENT_ID: "some_client_id"
       OP_AUTHORIZE_URL: "https://di-auth-oidc-provider.london.cloudapps.digital/authorize"
       OP_TOKEN_URL: "https://di-auth-oidc-provider.london.cloudapps.digital/token"

--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -eu
+
+echo "Building DI authentication Stub relying party"
+./gradlew clean build
+
+echo "Starting DI authentication Stub relying party"
+./gradlew run


### PR DESCRIPTION
- Upgrade gradle to the app can run on java16
- Upgrade the version of java in the manifest so the app can run on java16 on the PaaS
- Add startup.sh script to make it easier to run the app locally



