### PR TITLE
XytEISqB: Use correct environment variable for logout URL.

### DIFF
--- a/src/main/java/uk/gov/di/config/RelyingPartyConfig.java
+++ b/src/main/java/uk/gov/di/config/RelyingPartyConfig.java
@@ -7,7 +7,7 @@ public class RelyingPartyConfig {
     public static final String OP_TOKEN_URL=getConfigValue("OP_TOKEN_URL","http://localhost:8080/token");
     public static final String OP_USERINFO_URL=getConfigValue("OP_USERINFO_URL","http://localhost:8080/userinfo");
     public static final String AUTH_CALLBACK_URL=getConfigValue("AUTH_CALLBACK_URL","http://localhost:8081/oidc/callback");
-    public static final String LOGOUT_URL=getConfigValue("AUTH_CALLBACK_URL","http://localhost:8080/logout?redirectUri=http://localhost:8081/");
+    public static final String LOGOUT_URL=getConfigValue("LOGOUT_URL","http://localhost:8080/logout?redirectUri=http://localhost:8081/");
     public static final String PORT=getConfigValue("RP_PORT","8081");
 
     private static String getConfigValue(String key, String defaultValue){


### PR DESCRIPTION
## What?

Use the correct environment variable to determine what the logout URL is.

## Why?

This is failing in PaaS due to picking up the auth callback URL in error.

## Related PRs

#14 
