### PR TITLE
BAU: Enable debug on app JVM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,5 +17,13 @@ dependencies {
     testImplementation "junit:junit:4.12"
 
 }
+run {
+    debugOptions {
+        enabled = true
+        port = 8083
+        server = true
+        suspend = false
+    }
+}
 
 mainClassName = 'uk.gov.di.App'


### PR DESCRIPTION
## What?

Enable debug on app JVM on port 8083

## Why?

Useful for debugging applications.
