### PR TITLE
XytEISqB: A better logout button

### DIFF
--- a/src/main/java/uk/gov/di/OidcRp.java
+++ b/src/main/java/uk/gov/di/OidcRp.java
@@ -1,6 +1,7 @@
 package uk.gov.di;
 
 import static spark.Spark.port;
+import static spark.Spark.post;
 import static spark.Spark.staticFileLocation;
 import static spark.Spark.path;
 import static spark.Spark.get;
@@ -9,6 +10,7 @@ import static uk.gov.di.config.RelyingPartyConfig.PORT;
 import static uk.gov.di.handlers.HomeHandler.serveHomePage;
 import static uk.gov.di.handlers.OidcHandler.doAuthorize;
 import static uk.gov.di.handlers.OidcHandler.doAuthCallback;
+import static uk.gov.di.handlers.OidcHandler.doLogout;
 
 public class OidcRp {
     public OidcRp(){
@@ -25,6 +27,8 @@ public class OidcRp {
             get("/auth", doAuthorize);
             get("/callback", doAuthCallback);
         });
+
+        post("/logout", doLogout);
 
         internalServerError("<html><body><h1>Oops something went wrong</h1></body></html>");
     }

--- a/src/main/java/uk/gov/di/handlers/OidcHandler.java
+++ b/src/main/java/uk/gov/di/handlers/OidcHandler.java
@@ -61,6 +61,11 @@ public class OidcHandler {
         return ViewHelper.render(model, "userinfo.mustache");
     };
 
+    public static Route doLogout = (Request request, Response response) -> {
+        response.redirect(LOGOUT_URL);
+        return response;
+    };
+
     private static UserInfo getUserInfo(AccessToken accessToken) throws IOException, URISyntaxException, ParseException {
         var httpResponse = new UserInfoRequest(new URI(OP_USERINFO_URL), new BearerAccessToken(accessToken.toString()))
                 .toHTTPRequest()

--- a/src/main/resources/templates/userinfo.mustache
+++ b/src/main/resources/templates/userinfo.mustache
@@ -81,7 +81,9 @@
                     </div>
                 </dl>
             </div>
-            <a href="{{logoutUrl}}" class="govuk-button">Log out</a>
+            <form action="/logout" method="post">
+                <button class="govuk-button" type="submit" name="logout">Log out</button>
+            </form>
         </div>
     </main>
 </div>


### PR DESCRIPTION
## What?

Use a form post and a real button to do the logout rather than a simple link. 

## Why?

This allows you to put any RP specific logout logic before redirecting to IDP.

## Related PRs

#14 
