### PR TITLE
BAU - Remove cherrypy dependency from python app

### DIFF
--- a/example-clients/python/requirements.txt
+++ b/example-clients/python/requirements.txt
@@ -1,3 +1,2 @@
 flask
 oic
-cherrypy


### PR DESCRIPTION
## What?

- Remove cherrypy dependency from python app

## Why?

- It is not used so can be removed

