### PR TITLE
vT7VtuIb - Update python client sample implementation

### DIFF
--- a/example-clients/python/app/oidc-rp.py
+++ b/example-clients/python/app/oidc-rp.py
@@ -15,31 +15,38 @@ cache = {}
 logging.basicConfig()
 logger = logging.getLogger('oic.oauth2')
 app.config['BASE_URL'] = environ.get('BASE_URL')
+app.config['CLIENT_ID'] = environ.get('CLIENT_ID')
+app.config['CLIENT_SECRET'] = environ.get('CLIENT_SECRET')
 
 @app.route('/')
 def home():
     return render_template('home.html')
 
+@app.route('/register')
+def register():
+    client = Client(client_authn_method=CLIENT_AUTHN_METHOD, verify_ssl=False)
+    provider_info = _make_wellknown_request(client)
+    registration_response = _make_registration_request(client, provider_info["registration_endpoint"])
+    return registration_response.values()
+
 @app.route('/authorize')
 def make_authorization_request():
     client = Client(client_authn_method=CLIENT_AUTHN_METHOD, verify_ssl=False)
     provider_info = _make_wellknown_request(client)
-    registration_response = _make_registration_request(client, provider_info["registration_endpoint"])
-
+    client.store_registration_info(_generate_reg_info())
     session['state'] = rndstr()
     session["nonce"] = rndstr()
     args = {
         "client_id": client.client_id,
         "response_type": "code",
         "scope": ["openid"],
-        "redirect_uri": client.registration_response["redirect_uris"][0],
+        "redirect_uri": "http://localhost:5000/callback",
         "state": session.get('state'),
         "nonce": session.get('nonce')
     }
-    cache['client'] = client
     auth_req = client.construct_AuthorizationRequest(request_args=args)
     login_url = auth_req.request(client.authorization_endpoint)
-    
+    cache['client'] = client
     return Redirect(login_url)
 
 @app.route('/callback')
@@ -70,7 +77,7 @@ def _make_registration_request(client, registration_endpoint):
 def _make_token_request(client, code):
     args = {
         "code": code,
-        "redirect_uri": client.registration_response["redirect_uris"][0],
+        "redirect_uri": 'http://localhost:5000/callback',
         "client_id": client.client_id,
         "client_secret": client.client_secret
     }
@@ -79,5 +86,10 @@ def _make_token_request(client, code):
 def _make_userinfo_request(client, access_token):
     return client.do_user_info_request(method="GET", token=access_token, behavior="use_authorization_header")
 
-
+def _generate_reg_info():
+    reginfo = dict()
+    reginfo["client_secret"] = app.config['CLIENT_SECRET']
+    reginfo["client_id"] = app.config['CLIENT_ID']
+    reginfo["redirect_uris"] = 'http://localhost:5000/callback'
+    return reginfo
 

--- a/example-clients/python/requirements.txt
+++ b/example-clients/python/requirements.txt
@@ -1,3 +1,2 @@
 flask
 oic
-cherrypy

--- a/example-clients/python/startup.sh
+++ b/example-clients/python/startup.sh
@@ -19,7 +19,15 @@ done
 
 docker build -t python-client .
 if [[ ${USE_LOCAL_OIDC_PROVIDER} == "1" ]]; then
-    docker run -it -p 5000:5000 -e BASE_URL=http://localhost:8080 python-client 
+    docker run -it -p 5000:5000 \
+      -e BASE_URL=http://localhost:8080 \
+      -e CLIENT_ID=some_client_id \
+      -e CLIENT_SECRET=password \
+      python-client 
 else
-    docker run -it -p 5000:5000 -e BASE_URL=https://di-auth-oidc-provider.london.cloudapps.digital python-client
+    docker run -it -p 5000:5000 \
+      -e BASE_URL=https://di-auth-oidc-provider.london.cloudapps.digital \
+      -e CLIENT_ID=some_client_id \
+      -e CLIENT_SECRET=password \
+      python-client
 fi


### PR DESCRIPTION
## What?

- Use the same client credentials registered by the dummy RP
- Split out the registration endpoint. This won't be used but is there more for reference.
- Call the wellknown endpoint before the auth request to prevent the need to hardcode the details on the OIDC provider.
- Remove the cherrypy from requirements.txt as this is not used

## Why?

- So we can reuse the credentials of the dummy RP and make it a closer representation of what a real RP might look like
