### PR TITLE
LTG-101: add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM gradle:jdk16@sha256:d31e12d105e332ec2ef1f31c20eac6d1467295487ac70e534e3c1d0ae4a0506e AS build
+COPY --chown=gradle:gradle . /home/gradle/src
+WORKDIR /home/gradle/src
+RUN gradle clean build --no-daemon
+
+ENTRYPOINT ["gradle", "run"]


### PR DESCRIPTION
## What?

Add Dockerfile for di-auth-stub-relying-party.

## Why?

Support running locally on docker and docker compose.

## Related PRs

https://github.com/alphagov/di-auth-oidc-provider/pull/98
