### PR TITLE
BAU - Refactor Stub apps and pipeline

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -23,7 +23,7 @@ resources:
         - ci/pipeline.yaml
       branch: main
 
-  - name: di-auth-stub-relying-party-upload
+  - name: di-auth-stub-relying-party-upload-sandbox
     type: cf-cli
     icon: cloud-upload
     source:
@@ -32,6 +32,16 @@ resources:
       password: ((cf-password))
       org: gds-digital-identity-authentication
       space: sandbox
+
+  - name: di-auth-stub-relying-party-upload-build
+    type: cf-cli
+    icon: cloud-upload
+    source:
+      api: https://api.london.cloud.service.gov.uk
+      username: ((cf-username))
+      password: ((cf-password))
+      org: gds-digital-identity-authentication
+      space: build
 
 jobs:
   - name: update-pipeline
@@ -65,10 +75,23 @@ jobs:
               cd di-auth-stub-relying-party
               gradle --no-daemon build
               cp build/distributions/di-auth-stub-relying-party.zip ../di-auth-stub-relying-party-zip/
-    - put: di-auth-stub-relying-party-upload
+    - put: di-auth-stub-relying-party-upload-sandbox
       params:
         command: push
+        app_name: di-auth-stub-relying-party-sandbox
         manifest: di-auth-stub-relying-party/manifest.yml
         path: di-auth-stub-relying-party-zip/di-auth-stub-relying-party.zip
+        environment_variables:
+          OP_BASE_URL: ((sandbox-op-base-url))
+          STUB_BASE_URL: ((sandbox-stub-base-url))
+    - put: di-auth-stub-relying-party-upload-build
+      params:
+        command: push
+        app_name: di-auth-stub-relying-party-build
+        manifest: di-auth-stub-relying-party/manifest.yml
+        path: di-auth-stub-relying-party-zip/di-auth-stub-relying-party.zip
+        environment_variables:
+          OP_BASE_URL: ((build-op-base-url))
+          STUB_BASE_URL: ((build-stub-base-url))
 
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,6 @@
 ---
 applications:
-  - name: di-auth-stub-relying-party
+  - name: di-auth-stub-relying-party-sandbox
     path: build/distributions/di-auth-stub-relying-party.zip
     memory: 1G
     buildpack: java_buildpack
@@ -9,9 +9,14 @@ applications:
       JAVA_HOME: "../.java-buildpack/open_jdk_jre"
       JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 16.+}}'
       CLIENT_ID: "some_client_id"
-      OP_AUTHORIZE_URL: "https://di-auth-oidc-provider.london.cloudapps.digital/authorize"
-      OP_TOKEN_URL: "https://di-auth-oidc-provider.london.cloudapps.digital/token"
-      OP_USERINFO_URL: "https://di-auth-oidc-provider.london.cloudapps.digital/userinfo"
-      AUTH_CALLBACK_URL: "https://di-auth-stub-relying-party.london.cloudapps.digital/oidc/callback"
-      LOGOUT_URL: "https://di-auth-oidc-provider.london.cloudapps.digital/logout?redirectUri=https://di-auth-stub-relying-party.london.cloudapps.digital"
+      RP_PORT: "8080"
+  - name: di-auth-stub-relying-party-build
+    path: build/distributions/di-auth-stub-relying-party.zip
+    memory: 1G
+    buildpack: java_buildpack
+    command: cd di-auth-stub-relying-party && bin/di-auth-stub-relying-party
+    env:
+      JAVA_HOME: "../.java-buildpack/open_jdk_jre"
+      JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 16.+}}'
+      CLIENT_ID: "some_client_id"
       RP_PORT: "8080"

--- a/src/main/java/uk/gov/di/config/RelyingPartyConfig.java
+++ b/src/main/java/uk/gov/di/config/RelyingPartyConfig.java
@@ -1,14 +1,18 @@
 package uk.gov.di.config;
 
+import java.net.URI;
+import java.util.Optional;
+
 public class RelyingPartyConfig {
     public static final String CLIENT_ID= getConfigValue("CLIENT_ID", "some_client_id");
     public static final String CLIENT_SECRET = getConfigValue("CLIENT_SECRET", "password");
-    public static final String OP_AUTHORIZE_URL = getConfigValue("OP_AUTHORIZE_URL","http://localhost:8080/authorize");
-    public static final String OP_TOKEN_URL=getConfigValue("OP_TOKEN_URL","http://localhost:8080/token");
-    public static final String OP_USERINFO_URL=getConfigValue("OP_USERINFO_URL","http://localhost:8080/userinfo");
-    public static final String AUTH_CALLBACK_URL=getConfigValue("AUTH_CALLBACK_URL","http://localhost:8081/oidc/callback");
-    public static final String LOGOUT_URL=getConfigValue("LOGOUT_URL","http://localhost:8080/logout?redirectUri=http://localhost:8081/");
+    public static final String OP_AUTHORIZE_URL = getConfigValue("OP_BASE_URL","http://localhost:8080") + "/authorize";
+    public static final String OP_TOKEN_URL=getConfigValue("OP_BASE_URL","http://localhost:8080") + "/token";
+    public static final String OP_USERINFO_URL=getConfigValue("OP_BASE_URL","http://localhost:8080") + "/userinfo";
+    public static final String AUTH_CALLBACK_URL=getConfigValue("STUB_BASE_URL","http://localhost:8081") + "/oidc/callback";
+    public static final String LOGOUT_URL=generateLogoutUrl("OP_BASE_URL", "STUB_BASE_URL", "http://localhost:8080/logout?redirectUri=http://localhost:8081/");
     public static final String PORT=getConfigValue("RP_PORT","8081");
+
 
     private static String getConfigValue(String key, String defaultValue){
         var envValue = System.getenv(key);
@@ -17,5 +21,15 @@ public class RelyingPartyConfig {
         }
 
         return envValue;
+    }
+
+    private static String generateLogoutUrl(String baseUrlKey, String stubBaseUrlKey, String defaultValue) {
+        var baseUrlEnv = System.getenv(baseUrlKey);
+        var stubBaseUrlEnv = System.getenv(stubBaseUrlKey);
+
+        if (baseUrlEnv == null || stubBaseUrlEnv == null) {
+            return defaultValue;
+        }
+        return baseUrlEnv + "/logout?redirectUri=" + stubBaseUrlEnv;
     }
 }


### PR DESCRIPTION
## What?

- Create 2 instances of the Stub app. One to run in sandbox and one to run in the build environment.
- The Sandbox instance will run against the OP which was built in alpha whereas the Build instance will run against the what is currently being built in beta
- Change the domain of the Stub apps to include the environment E.G - di-auth-stub-relying-party-sandbox.london.cloudapps.digital
- Store the base urls in parameter store and build the URL in the RelyingPartyConfig instance. 

## Why?

- So it is clear what environment each Stub app is running in 
- Hide the BaseURLs until there is more protection on the Lambda endpoints
- So we can have multiple versions of the Stub App running

