### PR TITLE
GOVSI-514: deploy a second RP for testing SSO

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -93,5 +93,14 @@ jobs:
         environment_variables:
           OP_BASE_URL: ((build-op-base-url))
           STUB_BASE_URL: ((build-stub-base-url))
+    - put: di-auth-stub-relying-party-upload-build-s2
+      params:
+        command: push
+        app_name: di-auth-stub-relying-party-build-s2
+        manifest: di-auth-stub-relying-party/manifest.yml
+        path: di-auth-stub-relying-party-zip/di-auth-stub-relying-party.zip
+        environment_variables:
+          OP_BASE_URL: ((build-op-base-url))
+          STUB_BASE_URL: ((build-stub-base-url))
 
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -21,3 +21,16 @@ applications:
       CLIENT_ID: "SR-pLhOKIbJ6bFKq9VJPebIjsEY"
       CLIENT_SECRET: "test-secret"
       RP_PORT: "8080"
+      SERVICE_NAME: "Sample Service - Build S1"
+  - name: di-auth-stub-relying-party-build-s2
+    path: build/distributions/di-auth-stub-relying-party.zip
+    memory: 1G
+    buildpack: java_buildpack
+    command: cd di-auth-stub-relying-party && bin/di-auth-stub-relying-party
+    env:
+      JAVA_HOME: "../.java-buildpack/open_jdk_jre"
+      JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 16.+}}'
+      CLIENT_ID: "crkXDGK8gqIStiyAzY4ny-afKx4"
+      CLIENT_SECRET: "test-secret"
+      RP_PORT: "8080"
+      SERVICE_NAME: "Sample Service - Build S2"


### PR DESCRIPTION
## What?

Deploy a second RP for testing SSO.
Additional client registered in the API.

## Why?

We need two different services so we can test SSO and logout across two RPs.