### PR TITLE
GOVSI-514: add missing resource in pipeline

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -43,6 +43,16 @@ resources:
       org: gds-digital-identity-authentication
       space: build
 
+  - name: di-auth-stub-relying-party-upload-build-s2
+    type: cf-cli
+    icon: cloud-upload
+    source:
+      api: https://api.london.cloud.service.gov.uk
+      username: ((cf-username))
+      password: ((cf-password))
+      org: gds-digital-identity-authentication
+      space: build
+
 jobs:
   - name: update-pipeline
     plan:


### PR DESCRIPTION
## What?

Add missing resource in pipeline.

## Why?

Resource for the new second application is missing

## Related

#31 
