### PR TITLE
BAU: enable Dependabot for the repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "03:00"
+    open-pull-requests-limit: 10
+    target-branch: main
+    labels:
+      - dependabot


### PR DESCRIPTION
## What?

Enable Dependabot for the repo.

## Why?

Ensure library versions are up-to-date.