### PR TITLE
BAU: enforce a strict version for Jetty

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,12 @@ dependencies {
         "com.nimbusds:oauth2-oidc-sdk:9.3.1",
         "org.slf4j:slf4j-simple:1.7.2"
 
+    implementation('org.eclipse.jetty:jetty-server') {
+        version {
+            strictly '9.4.43.v20210629'
+        }
+    }
+
     testImplementation "junit:junit:4.12"
 
 }


### PR DESCRIPTION

## What?

Enforce a strict version for Jetty.

## Why?

Transitive version is not the latest.
