### PR TITLE
Remove id token validation

### DIFF
--- a/src/main/java/uk/gov/di/handlers/AuthCallbackHandler.java
+++ b/src/main/java/uk/gov/di/handlers/AuthCallbackHandler.java
@@ -21,8 +21,8 @@ public class AuthCallbackHandler implements Route {
     @Override
     public Object handle(Request request, Response response) throws Exception {
         var tokens = oidcClient.makeTokenRequest(request.queryParams("code"), AUTH_CALLBACK_URL);
-
-        oidcClient.validateIdToken(tokens.getIDToken());
+        //TODO add this back in when there is an endpoint to get the cert from
+        //oidcClient.validateIdToken(tokens.getIDToken());
         request.session().attribute("idToken", tokens.getIDToken().getParsedString());
 
         var userInfo = oidcClient.makeUserInfoRequest(tokens.getAccessToken());


### PR DESCRIPTION
## What?

Remove id token validation

## Why?

As there currently isn't a mechanism to get the public key to validate the id token.

