### PR TITLE
BAU: Update `STUB_BASE_URL`  env var on stub s2

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -113,7 +113,7 @@ jobs:
         path: di-auth-stub-relying-party-zip/di-auth-stub-relying-party.zip
         environment_variables:
           OP_BASE_URL: ((build-op-base-url))
-          STUB_BASE_URL: ((build-stub-base-url))
+          STUB_BASE_URL: ((build-stub-base-url-s2))
           CLIENT_PRIVATE_KEY: ((build-client-private-key))
 
 


### PR DESCRIPTION
## What?

- This value is different for each stub, correct value has been added to SSM as `build-stub-base-url-s2` parameter.

## Why?

Callback URL needs to be correct for S2.