### PR TITLE
BAU: Allow stubs to detect their own URLs and ports

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,8 @@ dependencies {
         "com.sparkjava:spark-template-mustache:2.7.1",
         "com.nimbusds:oauth2-oidc-sdk:9.10.1",
         "org.slf4j:slf4j-simple:1.7.32",
-            "org.apache.httpcomponents:httpclient:4.5.13"
+            "org.apache.httpcomponents:httpclient:4.5.13",
+            "io.pivotal.cfenv:java-cfenv:2.4.0"
 
     implementation('org.eclipse.jetty:jetty-server') {
         version {

--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -93,7 +93,6 @@ jobs:
         path: di-auth-stub-relying-party-zip/di-auth-stub-relying-party.zip
         environment_variables:
           OP_BASE_URL: ((sandbox-op-base-url))
-          STUB_BASE_URL: ((sandbox-stub-base-url))
           CLIENT_PRIVATE_KEY: ((sandbox-client-private-key))
     - put: di-auth-stub-relying-party-upload-build
       params:
@@ -103,7 +102,6 @@ jobs:
         path: di-auth-stub-relying-party-zip/di-auth-stub-relying-party.zip
         environment_variables:
           OP_BASE_URL: ((build-op-base-url))
-          STUB_BASE_URL: ((build-stub-base-url))
           CLIENT_PRIVATE_KEY: ((build-client-private-key))
     - put: di-auth-stub-relying-party-upload-build-s2
       params:
@@ -113,7 +111,6 @@ jobs:
         path: di-auth-stub-relying-party-zip/di-auth-stub-relying-party.zip
         environment_variables:
           OP_BASE_URL: ((build-op-base-url))
-          STUB_BASE_URL: ((build-stub-base-url-s2))
           CLIENT_PRIVATE_KEY: ((build-client-private-key))
 
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -19,7 +19,6 @@ applications:
       JAVA_HOME: "../.java-buildpack/open_jdk_jre"
       JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 16.+}}'
       CLIENT_ID: "SR-pLhOKIbJ6bFKq9VJPebIjsEY"
-      RP_PORT: "8080"
       SERVICE_NAME: "Sample Service - Build S1"
   - name: di-auth-stub-relying-party-build-s2
     path: build/distributions/di-auth-stub-relying-party.zip
@@ -30,5 +29,4 @@ applications:
       JAVA_HOME: "../.java-buildpack/open_jdk_jre"
       JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 16.+}}'
       CLIENT_ID: "crkXDGK8gqIStiyAzY4ny-afKx4"
-      RP_PORT: "8080"
       SERVICE_NAME: "Sample Service - Build S2"

--- a/src/main/java/uk/gov/di/OidcRp.java
+++ b/src/main/java/uk/gov/di/OidcRp.java
@@ -24,7 +24,7 @@ import static uk.gov.di.config.RelyingPartyConfig.IDP_URL;
 public class OidcRp {
     public OidcRp(){
         staticFileLocation("/public");
-        port(Integer.parseInt(PORT));
+        port(PORT);
 
         initRoutes();
     }

--- a/src/main/java/uk/gov/di/config/RelyingPartyConfig.java
+++ b/src/main/java/uk/gov/di/config/RelyingPartyConfig.java
@@ -1,13 +1,20 @@
 package uk.gov.di.config;
 
+import io.pivotal.cfenv.core.CfEnv;
+
+import static java.text.MessageFormat.format;
+
 public class RelyingPartyConfig {
+
+    private static final CfEnv cfEnv = new CfEnv();
+
     public static final String SERVICE_NAME = getConfigValue("SERVICE_NAME", "Sample Government Service");
     public static final String IDP_URL= getConfigValue("OP_BASE_URL", "https://api.build.auth.ida.digital.cabinet-office.gov.uk");
     public static final String CLIENT_ID= getConfigValue("CLIENT_ID", "some_client_id");
-    public static final String AUTH_CALLBACK_URL=getConfigValue("STUB_BASE_URL","http://localhost:8081") + "/oidc/authorization-code/callback";
-    public static final String POST_LOGOUT_REDIRECT_URL=getConfigValue("STUB_BASE_URL","http://localhost:8081") + "/signed-out";
+    public static final String AUTH_CALLBACK_URL=getCloudFoundryUri("http://localhost:8081") + "/oidc/authorization-code/callback";
+    public static final String POST_LOGOUT_REDIRECT_URL=getCloudFoundryUri("http://localhost:8081") + "/signed-out";
     public static final String CLIENT_PRIVATE_KEY =getConfigValue("CLIENT_PRIVATE_KEY","PRIVATE-KEY");
-    public static final String PORT=getConfigValue("RP_PORT","8081");
+    public static final int PORT=getCloudfoundryPort(8081);
 
     private static String getConfigValue(String key, String defaultValue){
         var envValue = System.getenv(key);
@@ -16,5 +23,19 @@ public class RelyingPartyConfig {
         }
 
         return envValue;
+    }
+
+    private static String getCloudFoundryUri(String defaultValue) {
+        if (cfEnv.isInCf() && cfEnv.getApp().getUris().size() > 0) {
+            return format("https://{0}", cfEnv.getApp().getUris().get(0));
+        }
+        return defaultValue;
+    }
+
+    private static int getCloudfoundryPort(int defaultValue) {
+        if (cfEnv.isInCf()) {
+            return 8080;
+        }
+        return defaultValue;
     }
 }


### PR DESCRIPTION
## What?

- Use the `java-cfenv` to detect if running in PaaS
- Use `java-cfenv` to get application URIs from `VCAP_APPLICATION` environment variable
- If running in PaaS use port `8080` otherwise whatever is specified.

## Why?

This is a better solution than injecting environment variables from the pipeline and storing the values in SSM.
