### PR TITLE
GOVSI-834: make 'my account' link configurable in the stub clients

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -12,3 +12,4 @@ applications:
       SERVICE_NAME: ((service_name))
       OP_BASE_URL: ((op_base_url))
       CLIENT_PRIVATE_KEY: ((client_private_key))
+      MY_ACCOUNT_URL: ((am_url))

--- a/src/main/java/uk/gov/di/config/RelyingPartyConfig.java
+++ b/src/main/java/uk/gov/di/config/RelyingPartyConfig.java
@@ -15,6 +15,7 @@ public class RelyingPartyConfig {
     public static final String POST_LOGOUT_REDIRECT_URL=getCloudFoundryUri("http://localhost:8081") + "/signed-out";
     public static final String CLIENT_PRIVATE_KEY =getConfigValue("CLIENT_PRIVATE_KEY","PRIVATE-KEY");
     public static final int PORT=getCloudfoundryPort(8081);
+    public static final String MY_ACCOUNT_URL = getConfigValue("MY_ACCOUNT_URL", "https://account-management.integration.auth.ida.digital.cabinet-office.gov.uk/");
 
     private static String getConfigValue(String key, String defaultValue){
         var envValue = System.getenv(key);

--- a/src/main/java/uk/gov/di/handlers/AuthCallbackHandler.java
+++ b/src/main/java/uk/gov/di/handlers/AuthCallbackHandler.java
@@ -9,6 +9,7 @@ import uk.gov.di.utils.ViewHelper;
 import java.util.HashMap;
 
 import static uk.gov.di.config.RelyingPartyConfig.AUTH_CALLBACK_URL;
+import static uk.gov.di.config.RelyingPartyConfig.MY_ACCOUNT_URL;
 
 public class AuthCallbackHandler implements Route {
 
@@ -29,6 +30,7 @@ public class AuthCallbackHandler implements Route {
         var model = new HashMap<>();
         model.put("email", userInfo.getEmailAddress());
         model.put("phone_number", userInfo.getPhoneNumber());
+        model.put("my_account_url", MY_ACCOUNT_URL);
 
         return ViewHelper.render(model, "userinfo.mustache");
     }

--- a/src/main/resources/templates/userinfo.mustache
+++ b/src/main/resources/templates/userinfo.mustache
@@ -51,7 +51,7 @@
             <nav>
                 <ul id="navigation" class="govuk-header__navigation " aria-label="Navigation menu" style="text-align: right">
                     <li class="govuk-header__navigation-item">
-                        <a class="govuk-header__link" href="https://account-management.integration.auth.ida.digital.cabinet-office.gov.uk/">
+                        <a class="govuk-header__link" href="{{my_account_url}}">
                            My Account
                         </a>
                     </li>


### PR DESCRIPTION
## What?

Make 'my account' link configurable in the stub clients.

## Why?

Each environment has a different account management instance.
Link is currently hard-coded to integration

## Related

https://github.com/alphagov/di-infrastructure/pull/61