### PR TITLE
BAU: provide id for sign in button

### DIFF
--- a/src/main/resources/templates/home.mustache
+++ b/src/main/resources/templates/home.mustache
@@ -156,7 +156,7 @@
                             </div>
                         </fieldset>
                             </div>
-                        <button data-prevent-double-click="true" class="govuk-button" data-module="govuk-button" type="submit">
+                        <button data-prevent-double-click="true" class="govuk-button" id="govuk-signin-button" data-module="govuk-button" type="submit">
                             Continue
                         </button>
                     </div>


### PR DESCRIPTION
## What?

Provide id for sign in button

## Why?

Acceptance tests look for the id in order to click on the button

## Related PRs

#68 