### PR TITLE
AUTH-1259 - Allow Stub RP to request claims

### DIFF
--- a/src/main/resources/templates/home.mustache
+++ b/src/main/resources/templates/home.mustache
@@ -97,7 +97,6 @@
                             </div>
                         </fieldset>
                     </div>
-
                         <div class="govuk-form-group">
                         <fieldset class="govuk-fieldset">
                             <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
@@ -151,6 +150,33 @@
                                     <input class="govuk-radios__input" id="loc-Pv" name="loc" type="radio" value="Pv" disabled>
                                     <label class="govuk-label govuk-radios__label" for="loc-Pv">
                                         Pv
+                                    </label>
+                                </div>
+                            </div>
+                        </fieldset>
+                        <fieldset class="govuk-fieldset">
+                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                                <h3 class="govuk-fieldset__heading">
+                                    Claims
+                                </h3>
+                            </legend>
+                            <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                                <div class="govuk-checkboxes__item">
+                                    <input class="govuk-checkboxes__input" id="claims-name" name="claims-name" type="checkbox" value="name" checked disabled>
+                                    <label class="govuk-label govuk-checkboxes__label" for="claims-name">
+                                        name
+                                    </label>
+                                </div>
+                                <div class="govuk-checkboxes__item">
+                                    <input class="govuk-checkboxes__input" id="claims-birthdate" name="claims-birthdate" type="checkbox" value="birthdate" checked>
+                                    <label class="govuk-label govuk-checkboxes__label" for="claims-birthdate">
+                                        birthdate
+                                    </label>
+                                </div>
+                                <div class="govuk-checkboxes__item">
+                                    <input class="govuk-checkboxes__input" id="claims-address" name="claims-address" type="checkbox" value="address" checked>
+                                    <label class="govuk-label govuk-checkboxes__label" for="claims-address">
+                                        address
                                     </label>
                                 </div>
                             </div>


### PR DESCRIPTION
## What?

- - Allow Stub RP to request claims
- Change AuthorizationRequest to AuthenticationRequest as the latter uses OIDC as oppose to OAuth.

## Why?

- An RP may request claims and these claims will most likely be supplied by IPV. We want the Stub RP to replicate the behaviour of an RP which would request claims so we can replicate the journey.