### PR TITLE
BAU - Fix Identity values in Stub

### DIFF
--- a/src/main/resources/templates/home.mustache
+++ b/src/main/resources/templates/home.mustache
@@ -129,27 +129,27 @@
                             </legend>
                             <div class="govuk-radios">
                                 <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="loc-Pl" name="loc" type="radio" value="Pl" disabled>
-                                    <label class="govuk-label govuk-radios__label" for="loc-Pl">
-                                        Pl
+                                    <input class="govuk-radios__input" id="loc-P1" name="loc" type="radio" value="P1" disabled>
+                                    <label class="govuk-label govuk-radios__label" for="loc-P1">
+                                        P1
                                     </label>
                                 </div>
                                 <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="loc-Pm" name="loc" type="radio" value="Pm" >
-                                    <label class="govuk-label govuk-radios__label" for="loc-Pm">
-                                        Pm (MVP)
+                                    <input class="govuk-radios__input" id="loc-P2" name="loc" type="radio" value="P2" >
+                                    <label class="govuk-label govuk-radios__label" for="loc-P2">
+                                        P2 (MVP)
                                     </label>
                                 </div>
                                 <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="loc-Ph" name="loc" type="radio" value="Ph" disabled>
-                                    <label class="govuk-label govuk-radios__label" for="loc-Ph">
-                                        Ph
+                                    <input class="govuk-radios__input" id="loc-P3" name="loc" type="radio" value="P3" disabled>
+                                    <label class="govuk-label govuk-radios__label" for="loc-P3">
+                                        P3
                                     </label>
                                 </div>
                                 <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="loc-Pv" name="loc" type="radio" value="Pv" disabled>
-                                    <label class="govuk-label govuk-radios__label" for="loc-Pv">
-                                        Pv
+                                    <input class="govuk-radios__input" id="loc-P4" name="loc" type="radio" value="P4" disabled>
+                                    <label class="govuk-label govuk-radios__label" for="loc-P4">
+                                        P4
                                     </label>
                                 </div>
                             </div>


### PR DESCRIPTION
## What?

- Fix Identity values in Stub

## Why?

- These have changed to use numbers which identify the level of assurance rather than letters