### PR TITLE
BAU: Refactoring and applying linter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,15 @@
+buildscript {
+    repositories {
+        maven {
+            url 'https://gds.jfrog.io/artifactory/di-allowed-repos'
+        }
+    }
+}
+
+plugins {
+    id "com.diffplug.spotless" version "6.3.0"
+}
+
 apply plugin: 'java'
 apply plugin: 'application'
 apply plugin: 'idea'
@@ -12,9 +24,9 @@ repositories {
 
 dependencies {
     implementation "com.sparkjava:spark-core:2.9.3",
-        "com.sparkjava:spark-template-mustache:2.7.1",
-        "com.nimbusds:oauth2-oidc-sdk:9.10.1",
-        "org.slf4j:slf4j-simple:1.7.32",
+            "com.sparkjava:spark-template-mustache:2.7.1",
+            "com.nimbusds:oauth2-oidc-sdk:9.10.1",
+            "org.slf4j:slf4j-simple:1.7.32",
             "org.apache.httpcomponents:httpclient:4.5.13",
             "io.pivotal.cfenv:java-cfenv:2.4.0"
 
@@ -25,8 +37,23 @@ dependencies {
     }
 
     testImplementation "junit:junit:4.13.2"
-
 }
+
+spotless {
+    ratchetFrom 'origin/main'
+
+    java {
+        target "**/*.java"
+        googleJavaFormat("1.13.0").aosp()
+        importOrder "", "javax", "java", "\\#"
+    }
+
+    groovyGradle {
+        target "**/*.gradle"
+        greclipse().configFile("tools/spotless-gradle.properties")
+    }
+}
+
 run {
     debugOptions {
         enabled = true

--- a/src/main/java/uk/gov/di/OidcRp.java
+++ b/src/main/java/uk/gov/di/OidcRp.java
@@ -1,36 +1,36 @@
 package uk.gov.di;
 
-import uk.gov.di.handlers.SignOutHandler;
-import uk.gov.di.handlers.HomeHandler;
-import uk.gov.di.handlers.AuthorizeHandler;
+import uk.gov.di.config.RelyingPartyConfig;
 import uk.gov.di.handlers.AuthCallbackHandler;
-import uk.gov.di.handlers.SignedOutHandler;
+import uk.gov.di.handlers.AuthorizeHandler;
 import uk.gov.di.handlers.ErrorHandler;
+import uk.gov.di.handlers.HomeHandler;
+import uk.gov.di.handlers.SignOutHandler;
+import uk.gov.di.handlers.SignedOutHandler;
 import uk.gov.di.utils.Oidc;
 import uk.gov.di.utils.PrivateKeyReader;
 
-import static spark.Spark.port;
 import static spark.Spark.get;
+import static spark.Spark.internalServerError;
+import static spark.Spark.path;
+import static spark.Spark.port;
 import static spark.Spark.post;
 import static spark.Spark.staticFileLocation;
-import static spark.Spark.path;
-import static spark.Spark.internalServerError;
-import static uk.gov.di.config.RelyingPartyConfig.CLIENT_ID;
-import static uk.gov.di.config.RelyingPartyConfig.PORT;
-import static uk.gov.di.config.RelyingPartyConfig.CLIENT_PRIVATE_KEY;
-import static uk.gov.di.config.RelyingPartyConfig.IDP_URL;
-
 
 public class OidcRp {
-    public OidcRp(){
+    public OidcRp() {
         staticFileLocation("/public");
-        port(PORT);
+        port(RelyingPartyConfig.getCloudfoundryPort());
 
         initRoutes();
     }
 
-    public void initRoutes(){
-        var oidcClient = new Oidc(IDP_URL, CLIENT_ID, new PrivateKeyReader(CLIENT_PRIVATE_KEY));
+    public void initRoutes() {
+        var oidcClient =
+                new Oidc(
+                        RelyingPartyConfig.oidcProviderUrl(),
+                        RelyingPartyConfig.clientId(),
+                        new PrivateKeyReader(RelyingPartyConfig.clientPrivateKey()));
 
         var homeHandler = new HomeHandler();
         var authorizeHandler = new AuthorizeHandler(oidcClient);
@@ -41,10 +41,12 @@ public class OidcRp {
 
         get("/", homeHandler);
 
-        path("/oidc", () -> {
-            post("/auth", authorizeHandler);
-            get("/authorization-code/callback", authCallbackHandler);
-        });
+        path(
+                "/oidc",
+                () -> {
+                    post("/auth", authorizeHandler);
+                    get("/authorization-code/callback", authCallbackHandler);
+                });
 
         post("/logout", logoutHandler);
         get("/signed-out", signedOutHandler);

--- a/src/main/java/uk/gov/di/config/RelyingPartyConfig.java
+++ b/src/main/java/uk/gov/di/config/RelyingPartyConfig.java
@@ -8,15 +8,6 @@ public class RelyingPartyConfig {
 
     private static final CfEnv cfEnv = new CfEnv();
 
-    public static final String SERVICE_NAME = serviceName();
-    public static final String IDP_URL = oidcProviderUrl();
-    public static final String CLIENT_ID = clientId();
-    public static final String AUTH_CALLBACK_URL = authCallbackUrl();
-    public static final String POST_LOGOUT_REDIRECT_URL = postLogoutRedirectUrl();
-    public static final String CLIENT_PRIVATE_KEY = clientPrivateKey();
-    public static final int PORT = getCloudfoundryPort();
-    public static final String MY_ACCOUNT_URL = accountManagementUrl();
-
     public static String authCallbackUrl() {
         return getCloudFoundryUri() + "/oidc/authorization-code/callback";
     }

--- a/src/main/java/uk/gov/di/config/RelyingPartyConfig.java
+++ b/src/main/java/uk/gov/di/config/RelyingPartyConfig.java
@@ -8,35 +8,66 @@ public class RelyingPartyConfig {
 
     private static final CfEnv cfEnv = new CfEnv();
 
-    public static final String SERVICE_NAME = getConfigValue("SERVICE_NAME", "Sample Government Service");
-    public static final String IDP_URL= getConfigValue("OP_BASE_URL", "https://api.build.auth.ida.digital.cabinet-office.gov.uk");
-    public static final String CLIENT_ID= getConfigValue("CLIENT_ID", "some_client_id");
-    public static final String AUTH_CALLBACK_URL=getCloudFoundryUri("http://localhost:8081") + "/oidc/authorization-code/callback";
-    public static final String POST_LOGOUT_REDIRECT_URL=getCloudFoundryUri("http://localhost:8081") + "/signed-out";
-    public static final String CLIENT_PRIVATE_KEY =getConfigValue("CLIENT_PRIVATE_KEY","PRIVATE-KEY");
-    public static final int PORT=getCloudfoundryPort(8081);
-    public static final String MY_ACCOUNT_URL = getConfigValue("MY_ACCOUNT_URL", "https://account-management.integration.auth.ida.digital.cabinet-office.gov.uk/");
+    public static final String SERVICE_NAME = serviceName();
+    public static final String IDP_URL = oidcProviderUrl();
+    public static final String CLIENT_ID = clientId();
+    public static final String AUTH_CALLBACK_URL = authCallbackUrl();
+    public static final String POST_LOGOUT_REDIRECT_URL = postLogoutRedirectUrl();
+    public static final String CLIENT_PRIVATE_KEY = clientPrivateKey();
+    public static final int PORT = getCloudfoundryPort();
+    public static final String MY_ACCOUNT_URL = accountManagementUrl();
 
-    private static String getConfigValue(String key, String defaultValue){
+    public static String authCallbackUrl() {
+        return getCloudFoundryUri() + "/oidc/authorization-code/callback";
+    }
+
+    public static String postLogoutRedirectUrl() {
+        return getCloudFoundryUri() + "/signed-out";
+    }
+
+    public static String clientPrivateKey() {
+        return getConfigValue("CLIENT_PRIVATE_KEY", "PRIVATE-KEY");
+    }
+
+    public static String accountManagementUrl() {
+        return getConfigValue(
+                "MY_ACCOUNT_URL",
+                "https://account-management.integration.auth.ida.digital.cabinet-office.gov.uk/");
+    }
+
+    public static String clientId() {
+        return getConfigValue("CLIENT_ID", "some_client_id");
+    }
+
+    public static String serviceName() {
+        return getConfigValue("SERVICE_NAME", "Sample Government Service");
+    }
+
+    public static String oidcProviderUrl() {
+        return getConfigValue(
+                "OP_BASE_URL", "https://api.build.auth.ida.digital.cabinet-office.gov.uk");
+    }
+
+    public static String getCloudFoundryUri() {
+        if (cfEnv.isInCf() && cfEnv.getApp().getUris().size() > 0) {
+            return format("https://{0}", cfEnv.getApp().getUris().get(0));
+        }
+        return "http://localhost:8081";
+    }
+
+    public static int getCloudfoundryPort() {
+        if (cfEnv.isInCf()) {
+            return 8080;
+        }
+        return 8081;
+    }
+
+    private static String getConfigValue(String key, String defaultValue) {
         var envValue = System.getenv(key);
-        if(envValue == null){
+        if (envValue == null) {
             return defaultValue;
         }
 
         return envValue;
-    }
-
-    private static String getCloudFoundryUri(String defaultValue) {
-        if (cfEnv.isInCf() && cfEnv.getApp().getUris().size() > 0) {
-            return format("https://{0}", cfEnv.getApp().getUris().get(0));
-        }
-        return defaultValue;
-    }
-
-    private static int getCloudfoundryPort(int defaultValue) {
-        if (cfEnv.isInCf()) {
-            return 8080;
-        }
-        return defaultValue;
     }
 }

--- a/src/main/java/uk/gov/di/config/RelyingPartyConfig.java
+++ b/src/main/java/uk/gov/di/config/RelyingPartyConfig.java
@@ -2,6 +2,7 @@ package uk.gov.di.config;
 
 import io.pivotal.cfenv.core.CfEnv;
 
+import static java.lang.System.getenv;
 import static java.text.MessageFormat.format;
 
 public class RelyingPartyConfig {
@@ -17,25 +18,25 @@ public class RelyingPartyConfig {
     }
 
     public static String clientPrivateKey() {
-        return getConfigValue("CLIENT_PRIVATE_KEY", "PRIVATE-KEY");
+        return configValue("CLIENT_PRIVATE_KEY", "PRIVATE-KEY");
     }
 
     public static String accountManagementUrl() {
-        return getConfigValue(
+        return configValue(
                 "MY_ACCOUNT_URL",
                 "https://account-management.integration.auth.ida.digital.cabinet-office.gov.uk/");
     }
 
     public static String clientId() {
-        return getConfigValue("CLIENT_ID", "some_client_id");
+        return configValue("CLIENT_ID", "some_client_id");
     }
 
     public static String serviceName() {
-        return getConfigValue("SERVICE_NAME", "Sample Government Service");
+        return configValue("SERVICE_NAME", "Sample Government Service");
     }
 
     public static String oidcProviderUrl() {
-        return getConfigValue(
+        return configValue(
                 "OP_BASE_URL", "https://api.build.auth.ida.digital.cabinet-office.gov.uk");
     }
 
@@ -53,12 +54,7 @@ public class RelyingPartyConfig {
         return 8081;
     }
 
-    private static String getConfigValue(String key, String defaultValue) {
-        var envValue = System.getenv(key);
-        if (envValue == null) {
-            return defaultValue;
-        }
-
-        return envValue;
+    private static String configValue(String key, String defaultValue) {
+        return getenv().getOrDefault(key, defaultValue);
     }
 }

--- a/src/main/java/uk/gov/di/handlers/AuthCallbackHandler.java
+++ b/src/main/java/uk/gov/di/handlers/AuthCallbackHandler.java
@@ -3,36 +3,35 @@ package uk.gov.di.handlers;
 import spark.Request;
 import spark.Response;
 import spark.Route;
+import uk.gov.di.config.RelyingPartyConfig;
 import uk.gov.di.utils.Oidc;
 import uk.gov.di.utils.ViewHelper;
 
 import java.util.HashMap;
 
-import static uk.gov.di.config.RelyingPartyConfig.AUTH_CALLBACK_URL;
-import static uk.gov.di.config.RelyingPartyConfig.MY_ACCOUNT_URL;
-
 public class AuthCallbackHandler implements Route {
 
     private Oidc oidcClient;
 
-    public AuthCallbackHandler(Oidc oidc){
+    public AuthCallbackHandler(Oidc oidc) {
         this.oidcClient = oidc;
     }
 
     @Override
     public Object handle(Request request, Response response) throws Exception {
-        var tokens = oidcClient.makeTokenRequest(request.queryParams("code"), AUTH_CALLBACK_URL);
+        var tokens =
+                oidcClient.makeTokenRequest(
+                        request.queryParams("code"), RelyingPartyConfig.authCallbackUrl());
 
         oidcClient.validateIdToken(tokens.getIDToken());
-        request.session().attribute("idToken",
-                tokens.getIDToken().getParsedString());
+        request.session().attribute("idToken", tokens.getIDToken().getParsedString());
 
         var userInfo = oidcClient.makeUserInfoRequest(tokens.getAccessToken());
 
         var model = new HashMap<>();
         model.put("email", userInfo.getEmailAddress());
         model.put("phone_number", userInfo.getPhoneNumber());
-        model.put("my_account_url", MY_ACCOUNT_URL);
+        model.put("my_account_url", RelyingPartyConfig.accountManagementUrl());
         model.put("id_token", tokens.getIDToken().getParsedString());
 
         return ViewHelper.render(model, "userinfo.mustache");

--- a/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
+++ b/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
@@ -6,45 +6,46 @@ import org.apache.http.client.utils.URLEncodedUtils;
 import spark.Request;
 import spark.Response;
 import spark.Route;
+import uk.gov.di.config.RelyingPartyConfig;
 import uk.gov.di.utils.Oidc;
 
-import javax.swing.text.html.Option;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
-
-import static uk.gov.di.config.RelyingPartyConfig.AUTH_CALLBACK_URL;
 
 public class AuthorizeHandler implements Route {
 
     private Oidc oidcClient;
 
-    public AuthorizeHandler(Oidc oidc){
+    public AuthorizeHandler(Oidc oidc) {
         this.oidcClient = oidc;
     }
 
     @Override
     public Object handle(Request request, Response response) {
 
-        try{
+        try {
             List<String> scopes = new ArrayList<>();
             scopes.add("openid");
 
             var claimsSetRequest = new ClaimsSetRequest();
 
-            List<NameValuePair> pairs = URLEncodedUtils.parse(request.body(), Charset.defaultCharset());
+            List<NameValuePair> pairs =
+                    URLEncodedUtils.parse(request.body(), Charset.defaultCharset());
 
-            Map<String, String> formParameters =  pairs.stream().collect(
-                    Collectors.toMap(NameValuePair::getName, NameValuePair::getValue));
+            Map<String, String> formParameters =
+                    pairs.stream()
+                            .collect(
+                                    Collectors.toMap(
+                                            NameValuePair::getName, NameValuePair::getValue));
 
-            if(formParameters.containsKey("scopes-email")){
+            if (formParameters.containsKey("scopes-email")) {
                 scopes.add(formParameters.get("scopes-email"));
             }
 
-            if(formParameters.containsKey("scopes-phone")){
+            if (formParameters.containsKey("scopes-phone")) {
                 scopes.add(formParameters.get("scopes-phone"));
             }
 
@@ -54,22 +55,24 @@ public class AuthorizeHandler implements Route {
                 vtr = "%s.%s".formatted(formParameters.get("loc"), vtr);
             }
 
-            if(formParameters.containsKey("claims-name")) {
+            if (formParameters.containsKey("claims-name")) {
                 claimsSetRequest.add(formParameters.get("claims-name"));
             }
 
-            if(formParameters.containsKey("claims-birthdate")) {
+            if (formParameters.containsKey("claims-birthdate")) {
                 claimsSetRequest.add(formParameters.get("claims-birthdate"));
             }
 
-            if(formParameters.containsKey("claims-address")) {
+            if (formParameters.containsKey("claims-address")) {
                 claimsSetRequest.add(formParameters.get("claims-address"));
             }
 
-            response.redirect(oidcClient.buildAuthorizeRequest(AUTH_CALLBACK_URL, vtr, scopes, claimsSetRequest));
+            response.redirect(
+                    oidcClient.buildAuthorizeRequest(
+                            RelyingPartyConfig.authCallbackUrl(), vtr, scopes, claimsSetRequest));
             return null;
 
-        }catch (Exception ex){
+        } catch (Exception ex) {
             throw new RuntimeException(ex);
         }
     }

--- a/src/main/java/uk/gov/di/handlers/HomeHandler.java
+++ b/src/main/java/uk/gov/di/handlers/HomeHandler.java
@@ -3,11 +3,10 @@ package uk.gov.di.handlers;
 import spark.Request;
 import spark.Response;
 import spark.Route;
+import uk.gov.di.config.RelyingPartyConfig;
 import uk.gov.di.utils.ViewHelper;
 
 import java.util.HashMap;
-
-import static uk.gov.di.config.RelyingPartyConfig.SERVICE_NAME;
 
 public class HomeHandler implements Route {
     @Override
@@ -15,7 +14,7 @@ public class HomeHandler implements Route {
         request.session(true);
 
         var model = new HashMap<>();
-        model.put("servicename", SERVICE_NAME);
+        model.put("servicename", RelyingPartyConfig.serviceName());
         return ViewHelper.render(model, "home.mustache");
     }
 }

--- a/src/main/java/uk/gov/di/handlers/SignOutHandler.java
+++ b/src/main/java/uk/gov/di/handlers/SignOutHandler.java
@@ -3,22 +3,25 @@ package uk.gov.di.handlers;
 import spark.Request;
 import spark.Response;
 import spark.Route;
+import uk.gov.di.config.RelyingPartyConfig;
 import uk.gov.di.utils.Oidc;
 
 import java.util.UUID;
 
-import static uk.gov.di.config.RelyingPartyConfig.POST_LOGOUT_REDIRECT_URL;
-
 public class SignOutHandler implements Route {
     private Oidc oidcClient;
 
-    public SignOutHandler(Oidc oidc){
+    public SignOutHandler(Oidc oidc) {
         this.oidcClient = oidc;
     }
 
     @Override
     public Object handle(Request request, Response response) throws Exception {
-        var logoutUri = oidcClient.buildLogoutUrl(request.session().attribute("idToken"), UUID.randomUUID().toString(), POST_LOGOUT_REDIRECT_URL);
+        var logoutUri =
+                oidcClient.buildLogoutUrl(
+                        request.session().attribute("idToken"),
+                        UUID.randomUUID().toString(),
+                        RelyingPartyConfig.postLogoutRedirectUrl());
         response.redirect(logoutUri);
         return null;
     }

--- a/src/main/resources/templates/home.mustache
+++ b/src/main/resources/templates/home.mustache
@@ -53,141 +53,130 @@
             </h1>
         </div>
         <div class="govuk-grid-row">
-            <div class="govuk-grid-column-two-thirds">
-                <h2 class="govuk-heading-l">Sign in</h2>
-                <div class="govuk-form-group">
-                    <label for="input-2acd6325" class=" govuk-label">Username</label>
-                    <input name="username" class="govuk-input govuk-input--width-20" id="input-2acd6325" type="text" tabindex="0" autofocus="autofocus">
-                </div>
-                <div class="govuk-form-group">
-                    <label for="input-d399210b" class=" govuk-label">Password</label>
-                    <input name="password" class="govuk-input govuk-input--width-20" id="input-d399210b" type="text">
-                </div>
-                <button class=" govuk-button" type="submit">Sign in</button>
-            </div>
-            <div class="govuk-grid-column-one-third">
-                <h2 class="govuk-heading-l">Continue with</h2>
-                <form method="post" action="/oidc/auth">
-                    <div class="govuk-form-group">
-                        <fieldset class="govuk-fieldset">
-                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-                                <h3 class="govuk-fieldset__heading">
-                                    Scopes
-                                </h3>
-                            </legend>
-                            <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-                                <div class="govuk-checkboxes__item">
-                                    <input class="govuk-checkboxes__input" id="scopes-openid" name="scopes" type="checkbox" value="openid" checked disabled>
-                                    <label class="govuk-label govuk-checkboxes__label" for="scopes-openid">
-                                        openid
-                                    </label>
-                                </div>
-                                <div class="govuk-checkboxes__item">
-                                    <input class="govuk-checkboxes__input" id="scopes-email" name="scopes-email" type="checkbox" value="email" checked>
-                                    <label class="govuk-label govuk-checkboxes__label" for="scopes-email">
-                                        email address
-                                    </label>
-                                </div>
-                                <div class="govuk-checkboxes__item">
-                                    <input class="govuk-checkboxes__input" id="scopes-phone" name="scopes-phone" type="checkbox" value="phone" checked>
-                                    <label class="govuk-label govuk-checkboxes__label" for="scopes-phone">
-                                        phone number
-                                    </label>
-                                </div>
+            <form method="post" action="/oidc/auth">
+                <div class="govuk-grid-column-one-quarter govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                            <h3 class="govuk-fieldset__heading">
+                                Scopes
+                            </h3>
+                        </legend>
+                        <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="scopes-openid" name="scopes" type="checkbox" value="openid" checked disabled>
+                                <label class="govuk-label govuk-checkboxes__label" for="scopes-openid">
+                                    openid
+                                </label>
                             </div>
-                        </fieldset>
-                    </div>
-                        <div class="govuk-form-group">
-                        <fieldset class="govuk-fieldset">
-                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-                                <h3 class="govuk-fieldset__heading">
-                                    Second factor auth
-                                </h3>
-                            </legend>
-                            <div class="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="2fa-on" name="2fa" type="radio" value="Cl.Cm" checked>
-                                    <label class="govuk-label govuk-radios__label" for="2fa-on">
-                                        2FA
-                                    </label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="2fa-off" name="2fa" type="radio" value="Cl">
-                                    <label class="govuk-label govuk-radios__label" for="2fa-off">
-                                        No 2FA
-                                    </label>
-                                </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="scopes-email" name="scopes-email" type="checkbox" value="email" checked>
+                                <label class="govuk-label govuk-checkboxes__label" for="scopes-email">
+                                    email address
+                                </label>
                             </div>
-                        </fieldset>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="scopes-phone" name="scopes-phone" type="checkbox" value="phone" checked>
+                                <label class="govuk-label govuk-checkboxes__label" for="scopes-phone">
+                                    phone number
+                                </label>
+                            </div>
                         </div>
-                            <div class="govuk-form-group">
-                        <fieldset class="govuk-fieldset">
-                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-                                <h3 class="govuk-fieldset__heading">
-                                    Level of confidence
-                                </h3>
-                            </legend>
-                            <div class="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="loc-P1" name="loc" type="radio" value="P1" disabled>
-                                    <label class="govuk-label govuk-radios__label" for="loc-P1">
-                                        P1
-                                    </label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="loc-P2" name="loc" type="radio" value="P2" >
-                                    <label class="govuk-label govuk-radios__label" for="loc-P2">
-                                        P2 (MVP)
-                                    </label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="loc-P3" name="loc" type="radio" value="P3" disabled>
-                                    <label class="govuk-label govuk-radios__label" for="loc-P3">
-                                        P3
-                                    </label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="loc-P4" name="loc" type="radio" value="P4" disabled>
-                                    <label class="govuk-label govuk-radios__label" for="loc-P4">
-                                        P4
-                                    </label>
-                                </div>
+                    </fieldset>
+                </div>
+                <div class="govuk-grid-column-one-quarter govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                            <h3 class="govuk-fieldset__heading">
+                                Second factor auth
+                            </h3>
+                        </legend>
+                        <div class="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="2fa-on" name="2fa" type="radio" value="Cl.Cm" checked>
+                                <label class="govuk-label govuk-radios__label" for="2fa-on">
+                                    2FA
+                                </label>
                             </div>
-                        </fieldset>
-                        <fieldset class="govuk-fieldset">
-                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-                                <h3 class="govuk-fieldset__heading">
-                                    Claims
-                                </h3>
-                            </legend>
-                            <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-                                <div class="govuk-checkboxes__item">
-                                    <input class="govuk-checkboxes__input" id="claims-name" name="claims-name" type="checkbox" value="name" checked>
-                                    <label class="govuk-label govuk-checkboxes__label" for="claims-name">
-                                        name
-                                    </label>
-                                </div>
-                                <div class="govuk-checkboxes__item">
-                                    <input class="govuk-checkboxes__input" id="claims-birthdate" name="claims-birthdate" type="checkbox" value="birthdate" checked>
-                                    <label class="govuk-label govuk-checkboxes__label" for="claims-birthdate">
-                                        birthdate
-                                    </label>
-                                </div>
-                                <div class="govuk-checkboxes__item">
-                                    <input class="govuk-checkboxes__input" id="claims-address" name="claims-address" type="checkbox" value="address" checked>
-                                    <label class="govuk-label govuk-checkboxes__label" for="claims-address">
-                                        address
-                                    </label>
-                                </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="2fa-off" name="2fa" type="radio" value="Cl">
+                                <label class="govuk-label govuk-radios__label" for="2fa-off">
+                                    No 2FA
+                                </label>
                             </div>
-                        </fieldset>
+                        </div>
+                    </fieldset>
+                </div>
+                <div class="govuk-grid-column-one-quarter govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                            <h3 class="govuk-fieldset__heading">
+                                Level of confidence
+                            </h3>
+                        </legend>
+                        <div class="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="loc-P1" name="loc" type="radio" value="P1" disabled>
+                                <label class="govuk-label govuk-radios__label" for="loc-P1">
+                                    P1
+                                </label>
                             </div>
-                        <button data-prevent-double-click="true" class="govuk-button" id="govuk-signin-button" data-module="govuk-button" type="submit">
-                            Continue
-                        </button>
-                    </div>
-                </form>
-            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="loc-P2" name="loc" type="radio" value="P2" >
+                                <label class="govuk-label govuk-radios__label" for="loc-P2">
+                                    P2 (MVP)
+                                </label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="loc-P3" name="loc" type="radio" value="P3" disabled>
+                                <label class="govuk-label govuk-radios__label" for="loc-P3">
+                                    P3
+                                </label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="loc-P4" name="loc" type="radio" value="P4" disabled>
+                                <label class="govuk-label govuk-radios__label" for="loc-P4">
+                                    P4
+                                </label>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <div class="govuk-grid-column-one-quarter govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                            <h3 class="govuk-fieldset__heading">
+                                Claims
+                            </h3>
+                        </legend>
+                        <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="claims-name" name="claims-name" type="checkbox" value="name" checked>
+                                <label class="govuk-label govuk-checkboxes__label" for="claims-name">
+                                    name
+                                </label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="claims-birthdate" name="claims-birthdate" type="checkbox" value="birthdate" checked>
+                                <label class="govuk-label govuk-checkboxes__label" for="claims-birthdate">
+                                    birthdate
+                                </label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="claims-address" name="claims-address" type="checkbox" value="address" checked>
+                                <label class="govuk-label govuk-checkboxes__label" for="claims-address">
+                                    address
+                                </label>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+
+                <div class="govuk-grid-column-full">
+                <button data-prevent-double-click="true" class="govuk-button" id="govuk-signin-button" data-module="govuk-button" type="submit">
+                    Continue
+                </button>
+                </div>
+            </form>
         </div>
     </main>
 </div>

--- a/tools/spotless-gradle.properties
+++ b/tools/spotless-gradle.properties
@@ -1,0 +1,14 @@
+#Whether to use 'space', 'tab' or 'mixed' (both) characters for indentation.
+#The default value is 'tab'.
+org.eclipse.jdt.core.formatter.tabulation.char=space
+
+#Whether or not indentation characters are inserted into empty lines.
+#The default value is 'true'.
+org.eclipse.jdt.core.formatter.indent_empty_lines=false
+
+#Length after which list are considered too long. These will be wrapped.
+#The default value is 30.
+groovy.formatter.longListLength=30
+
+#Remove unnecessary semicolons. The default value is 'false'.
+groovy.formatter.remove.unnecessary.semicolons=true


### PR DESCRIPTION
## What?

Giving a bit of TLC to our stub

- BAU: Create spotless configuration ratcheting from main
- BAU: Reformat and fix HTML
- BAU: Refactor configuration into provider methods. Apply Spotless
- BAU: Inline static fields to use providers directly
- BAU: Use `getenv().getOrDefault()` instead of our own logic

The UI now looks like:

![Screenshot 2022-03-04 at 12 23 56](https://user-images.githubusercontent.com/460299/156766648-b5811cec-e3c6-4fd8-a8cf-95f045c71dda.png)