### PR TITLE
AUTH-1444: ability to read .env file when running locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ build/
 node_modules
 example-clients/python/app/*.pyc
 example-clients/python/app/__pycache__
+.env
+.java-version

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.api.JavaVersion
+
 buildscript {
     repositories {
         maven {
@@ -54,12 +56,23 @@ spotless {
     }
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_16
+    targetCompatibility = JavaVersion.VERSION_16
+}
+
 run {
     debugOptions {
         enabled = true
         port = 8083
         server = true
         suspend = false
+    }
+    file('.env').exists() && file('.env').readLines().each() {
+        if (!it.isEmpty() && !it.startsWith('#') && it.contains('=')) {
+            def (key, value) = it.tokenize('=')
+            environment key, value
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -57,8 +57,8 @@ spotless {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_16
-    targetCompatibility = JavaVersion.VERSION_16
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 run {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,5 @@
+org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/manifest.yml
+++ b/manifest.yml
@@ -7,7 +7,7 @@ applications:
     command: cd di-auth-stub-relying-party && bin/di-auth-stub-relying-party
     env:
       JAVA_HOME: "../.java-buildpack/open_jdk_jre"
-      JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 16.+}}'
+      JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 17.+}}'
       CLIENT_ID: ((client_id))
       SERVICE_NAME: ((service_name))
       OP_BASE_URL: ((op_base_url))


### PR DESCRIPTION
## What?

Ability to read .env file when running locally.
Set java version in build.gradle

## Why?

Default configuration is hardcoded.  Some of this configuration is secret so need to be able to read it from environment variables when running locally.

