### PR TITLE
AUTH-1444: add option to select P0 - none

### DIFF
--- a/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
+++ b/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
@@ -51,7 +51,7 @@ public class AuthorizeHandler implements Route {
 
             String vtr = formParameters.get("2fa");
 
-            if (formParameters.containsKey("loc")) {
+            if (formParameters.containsKey("loc") && !formParameters.get("loc").isEmpty()) {
                 vtr = "%s.%s".formatted(formParameters.get("loc"), vtr);
             }
 

--- a/src/main/resources/templates/home.mustache
+++ b/src/main/resources/templates/home.mustache
@@ -115,6 +115,12 @@
                         </legend>
                         <div class="govuk-radios">
                             <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="loc-P0" name="loc" type="radio" value="" checked>
+                                <label class="govuk-label govuk-radios__label" for="loc-P0">
+                                    P0 - none
+                                </label>
+                            </div>
+                            <div class="govuk-radios__item">
                                 <input class="govuk-radios__input" id="loc-P1" name="loc" type="radio" value="P1" disabled>
                                 <label class="govuk-label govuk-radios__label" for="loc-P1">
                                     P1


### PR DESCRIPTION
## What?

Add option to select P0 - none.

## Why?

Option is selected by default and does not pass any P value on calling /authorize.

Gives us a way to test the non-IPV/authentication only journey explicitly.

