### PR TITLE
AUT-309: Fix buildpack URL

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -3,7 +3,8 @@ applications:
   - name: ((app_name))
     path: build/distributions/di-auth-stub-relying-party.zip
     memory: 1G
-    buildpack: https://github.com/cloudfoundry/java-buildpack/releases/tag/v4.48.3
+    buildpacks:
+      - https://github.com/cloudfoundry/java-buildpack.git#v4.48.3
     command: cd di-auth-stub-relying-party && bin/di-auth-stub-relying-party
     env:
       JAVA_HOME: "../.java-buildpack/open_jdk_jre"


### PR DESCRIPTION
This also switches to using `buildpacks` because `buildpack` is a deprecated field