### PR TITLE
AUT-295 - Support a Doc Checking App Stub

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -13,4 +13,5 @@ applications:
       SERVICE_NAME: ((service_name))
       OP_BASE_URL: ((op_base_url))
       CLIENT_PRIVATE_KEY: ((client_private_key))
+      CLIENT_TYPE: ((client_type))
       MY_ACCOUNT_URL: ((am_url))

--- a/src/main/java/uk/gov/di/config/RelyingPartyConfig.java
+++ b/src/main/java/uk/gov/di/config/RelyingPartyConfig.java
@@ -31,6 +31,10 @@ public class RelyingPartyConfig {
         return configValue("CLIENT_ID", "some_client_id");
     }
 
+    public static String clientType() {
+        return configValue("CLIENT_TYPE", "web");
+    }
+
     public static String serviceName() {
         return configValue("SERVICE_NAME", "Sample Government Service");
     }

--- a/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
+++ b/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
@@ -30,8 +30,6 @@ public class AuthorizeHandler implements Route {
             List<String> scopes = new ArrayList<>();
             scopes.add("openid");
 
-            var claimsSetRequest = new ClaimsSetRequest();
-
             List<NameValuePair> pairs =
                     URLEncodedUtils.parse(request.body(), Charset.defaultCharset());
 
@@ -40,6 +38,14 @@ public class AuthorizeHandler implements Route {
                             .collect(
                                     Collectors.toMap(
                                             NameValuePair::getName, NameValuePair::getValue));
+
+            if (formParameters.containsKey("scopes-doc-checking-app")) {
+                scopes.add(formParameters.get("scopes-doc-checking-app"));
+                response.redirect(
+                        oidcClient.buildSecureAuthorizeRequest(
+                                RelyingPartyConfig.authCallbackUrl(), scopes.toString()));
+                return null;
+            }
 
             if (formParameters.containsKey("scopes-email")) {
                 scopes.add(formParameters.get("scopes-email"));
@@ -54,6 +60,8 @@ public class AuthorizeHandler implements Route {
             if (formParameters.containsKey("loc") && !formParameters.get("loc").isEmpty()) {
                 vtr = "%s.%s".formatted(formParameters.get("loc"), vtr);
             }
+
+            var claimsSetRequest = new ClaimsSetRequest();
 
             if (formParameters.containsKey("claims-name")) {
                 claimsSetRequest.add(formParameters.get("claims-name"));

--- a/src/main/java/uk/gov/di/handlers/HomeHandler.java
+++ b/src/main/java/uk/gov/di/handlers/HomeHandler.java
@@ -15,6 +15,10 @@ public class HomeHandler implements Route {
 
         var model = new HashMap<>();
         model.put("servicename", RelyingPartyConfig.serviceName());
-        return ViewHelper.render(model, "home.mustache");
+        if (RelyingPartyConfig.clientType().equals("app")) {
+            return ViewHelper.render(model, "app-home.mustache");
+        } else {
+            return ViewHelper.render(model, "home.mustache");
+        }
     }
 }

--- a/src/main/resources/templates/app-home.mustache
+++ b/src/main/resources/templates/app-home.mustache
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en" class="govuk-template ">
+<head>
+    <title>{{servicename}} - GOV.UK</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <meta name="theme-color" content="#0b0c0c">
+
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="/gds/assets/images/favicon.ico" type="image/x-icon">
+    <link rel="mask-icon" href="/gds/assets/images/govuk-mask-icon.svg" color="#0b0c0c">
+    <link rel="apple-touch-icon" sizes="180x180" href="/gds/assets/images/govuk-apple-touch-icon-180x180.png">
+    <link rel="apple-touch-icon" sizes="167x167" href="/gds/assets/images/govuk-apple-touch-icon-167x167.png">
+    <link rel="apple-touch-icon" sizes="152x152" href="/gds/assets/images/govuk-apple-touch-icon-152x152.png">
+    <link rel="apple-touch-icon" href="/gds/assets/images/govuk-apple-touch-icon.png">
+
+    <!--[if !IE 8]><!-->
+    <link rel="stylesheet" href="/gds/govuk-frontend-3.11.0.min.css">
+    <!--<![endif]-->
+    <!--[if IE 8]>
+    <link rel="stylesheet" href="/gds/govuk-frontend-ie8-3.11.0.min.css">
+    <![endif]-->
+</head>
+<body class="govuk-template__body ">
+<script>
+    document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+</script>
+<a href="#main-content" class="govuk-skip-link">Skip to main content</a>
+
+<header class="govuk-header " role="banner" data-module="govuk-header">
+    <div class="govuk-header__container govuk-width-container">
+        <div class="govuk-header__logo">
+            <a href="/" class="govuk-header__link govuk-header__link--homepage">
+          <span class="govuk-header__logotype">
+            <svg aria-hidden="true" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 132 97" height="30" width="36">
+              <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
+              <image src="/assets/images/govuk-logotype-crown.png" xlink:href="data:," display="none" class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
+            </svg>
+            <span class="govuk-header__logotype-text">
+              GOV.UK
+            </span>
+          </span>
+            </a>
+        </div>
+    </div>
+</header>
+
+<div class="govuk-width-container ">
+    <main class="govuk-main-wrapper>" id="main-content" role="main">
+        <div class="govuk-!-margin-top-8 govuk-!-margin-bottom-9">
+            <h1 class="govuk-heading-xl">
+                {{servicename}}
+            </h1>
+        </div>
+        <div class="govuk-grid-row">
+            <form method="post" action="/oidc/auth">
+                <div class="govuk-grid-column-one-quarter govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                            <h3 class="govuk-fieldset__heading">
+                                Scopes
+                            </h3>
+                        </legend>
+                        <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="scopes-openid" name="scopes" type="checkbox" value="openid" checked disabled>
+                                <label class="govuk-label govuk-checkboxes__label" for="scopes-openid">
+                                    openid
+                                </label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="scopes-doc-checking-app" name="scopes-doc-checking-app" type="checkbox" value="doc-checking-app" checked disabled>
+                                <label class="govuk-label govuk-checkboxes__label" for="scopes-doc-checking-app">
+                                    doc-checking-app
+                                </label>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <div class="govuk-grid-column-full">
+                <button data-prevent-double-click="true" class="govuk-button" id="govuk-signin-button" data-module="govuk-button" type="submit">
+                    Continue
+                </button>
+                </div>
+            </form>
+        </div>
+    </main>
+</div>
+
+<footer class="govuk-footer " role="contentinfo">
+    <div class="govuk-width-container ">
+        <div class="govuk-footer__meta">
+            <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+
+                <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
+                    <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
+                </svg>
+                <span class="govuk-footer__licence-description">
+            All content is available under the
+            <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+          </span>
+            </div>
+            <div class="govuk-footer__meta-item">
+                <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
+            </div>
+        </div>
+    </div>
+</footer>
+<script src="/gds/govuk-frontend-3.11.0.min.js"></script>
+<script>
+    window.GOVUKFrontend.initAll()
+</script>
+</body>
+</html>


### PR DESCRIPTION
## What?

- When the ClientType is `app` then load up the `app-home.mustache` where the only scopes are `openid` and `doc-checking-app` which are already selected. This will differentiate it from the other stubs.
- When the user clicks `Continue` then call the `AuthorizeHandler` which will submit an auth requests using the secure JWT request object. This will be signed with the same RSA key as the PrivateKeyJWT.
- Use the same callback path for now as the other stub.
- Add CLIENT_TYPE to the manifest, this value will be set in concourse.

## Why?

- So we can test out the journey from a Doc Checking App Stub
