### PR TITLE
AUT-295 - Check if ClientType is app

### DIFF
--- a/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
+++ b/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
@@ -30,6 +30,14 @@ public class AuthorizeHandler implements Route {
             List<String> scopes = new ArrayList<>();
             scopes.add("openid");
 
+            if (RelyingPartyConfig.clientType().equals("app")) {
+                scopes.add("doc-checking-app");
+                response.redirect(
+                        oidcClient.buildSecureAuthorizeRequest(
+                                RelyingPartyConfig.authCallbackUrl(), scopes.toString()));
+                return null;
+            }
+
             List<NameValuePair> pairs =
                     URLEncodedUtils.parse(request.body(), Charset.defaultCharset());
 
@@ -38,14 +46,6 @@ public class AuthorizeHandler implements Route {
                             .collect(
                                     Collectors.toMap(
                                             NameValuePair::getName, NameValuePair::getValue));
-
-            if (formParameters.containsKey("scopes-doc-checking-app")) {
-                scopes.add(formParameters.get("scopes-doc-checking-app"));
-                response.redirect(
-                        oidcClient.buildSecureAuthorizeRequest(
-                                RelyingPartyConfig.authCallbackUrl(), scopes.toString()));
-                return null;
-            }
 
             if (formParameters.containsKey("scopes-email")) {
                 scopes.add(formParameters.get("scopes-email"));


### PR DESCRIPTION
## What?

- Check if ClientType is app

## Why?

- It didn't seem to pick up the form parameters, maybe because it was defaulted it to checked. Go about this another way by checking that the ClientType is `app` and then trigger a secure request


