### PR TITLE
BAU - Scopes need to be a string instead of a list

### DIFF
--- a/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
+++ b/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
@@ -1,5 +1,6 @@
 package uk.gov.di.handlers;
 
+import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
@@ -34,7 +35,7 @@ public class AuthorizeHandler implements Route {
                 scopes.add("doc-checking-app");
                 response.redirect(
                         oidcClient.buildSecureAuthorizeRequest(
-                                RelyingPartyConfig.authCallbackUrl(), scopes.toString()));
+                                RelyingPartyConfig.authCallbackUrl(), Scope.parse(scopes)));
                 return null;
             }
 

--- a/src/main/java/uk/gov/di/utils/Oidc.java
+++ b/src/main/java/uk/gov/di/utils/Oidc.java
@@ -170,7 +170,7 @@ public class Oidc {
         return authorizationRequestBuilder.build().toURI().toString();
     }
 
-    public String buildSecureAuthorizeRequest(String callbackUrl, String scopes) {
+    public String buildSecureAuthorizeRequest(String callbackUrl, Scope scopes) {
         var authRequestBuilder =
                 new AuthorizationRequest.Builder(
                                 new ResponseType(ResponseType.Value.CODE),
@@ -232,13 +232,13 @@ public class Oidc {
         }
     }
 
-    private SignedJWT generateSignedJWT(String scopes, String callbackURL) {
+    private SignedJWT generateSignedJWT(Scope scopes, String callbackURL) {
         var jwtClaimsSet =
                 new JWTClaimsSet.Builder()
                         .audience(this.providerMetadata.getAuthorizationEndpointURI().toString())
                         .claim("redirect_uri", callbackURL)
                         .claim("response_type", ResponseType.CODE.toString())
-                        .claim("scope", scopes)
+                        .claim("scope", scopes.toString())
                         .claim("client_id", this.clientId)
                         .claim("state", new State())
                         .issuer(this.clientId)


### PR DESCRIPTION
## What?

- Scopes need to be a string instead of a list

## Why?

- Otherwise it will not be able to be parsed
