### PR TITLE
BAU - Use the value of state in request object instead of the State object itself

### DIFF
--- a/src/main/java/uk/gov/di/utils/Oidc.java
+++ b/src/main/java/uk/gov/di/utils/Oidc.java
@@ -240,7 +240,7 @@ public class Oidc {
                         .claim("response_type", ResponseType.CODE.toString())
                         .claim("scope", scopes.toString())
                         .claim("client_id", this.clientId)
-                        .claim("state", new State())
+                        .claim("state", new State().getValue())
                         .issuer(this.clientId)
                         .build();
         var jwsHeader = new JWSHeader(JWSAlgorithm.RS512);


### PR DESCRIPTION
## What?

Use the value of state in request object instead of the State object itself

## Why?

- Otherwise it cannot be parsed