### PR TITLE
AUT-364: Support sending of P0 level of confidence

### DIFF
--- a/src/main/resources/templates/home.mustache
+++ b/src/main/resources/templates/home.mustache
@@ -115,7 +115,13 @@
                         </legend>
                         <div class="govuk-radios">
                             <div class="govuk-radios__item">
-                                <input class="govuk-radios__input" id="loc-P0" name="loc" type="radio" value="" checked>
+                                <input class="govuk-radios__input" id="loc-none" name="loc" type="radio" value="" checked>
+                                <label class="govuk-label govuk-radios__label" for="loc-none">
+                                    None - do not send
+                                </label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="loc-P0" name="loc" type="radio" value="P0">
                                 <label class="govuk-label govuk-radios__label" for="loc-P0">
                                     P0 - none
                                 </label>
@@ -127,7 +133,7 @@
                                 </label>
                             </div>
                             <div class="govuk-radios__item">
-                                <input class="govuk-radios__input" id="loc-P2" name="loc" type="radio" value="P2" >
+                                <input class="govuk-radios__input" id="loc-P2" name="loc" type="radio" value="P2">
                                 <label class="govuk-label govuk-radios__label" for="loc-P2">
                                     P2 (MVP)
                                 </label>


### PR DESCRIPTION
## What?

- Update P0 option to send `P0`
- Add new option for "None" which won't send an LoC

## Why?

We have added P0 support to the API, we should update the stub to allow us to test this.