### PR TITLE
AUT-386: stub rp route service configuration

### DIFF
--- a/nginx/manifest.yml
+++ b/nginx/manifest.yml
@@ -1,0 +1,16 @@
+---
+
+applications:
+  - name: ((app-name))
+    instances: 2
+    memory: 256M
+
+    buildpacks:
+      - nginx_buildpack
+
+    health-check-type: http
+    health-check-http-endpoint: /_route-service-health
+
+    env:
+      APP_NAME: ((app-name))
+      ALLOWED_IPS: ((allowed-ips))

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,111 @@
+worker_processes 4;
+daemon off;
+
+error_log /dev/stderr;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  charset utf-8;
+
+  log_format access_json '{"logType": "nginx-access", '
+                         ' "remoteHost": "$remote_addr", '
+                         ' "user": "$remote_user", '
+                         ' "time": "$time_local", '
+                         ' "request": "$request", '
+                         ' "status": $status, '
+                         ' "size": $body_bytes_sent, '
+                         ' "referer": "$http_referer", '
+                         ' "userAgent": "$http_user_agent", '
+                         ' "requestTime": $request_time, '
+                         ' "httpHost": "$http_host"}';
+
+  access_log /dev/stdout access_json;
+  default_type application/octet-stream;
+  sendfile on;
+  tcp_nopush on;
+  keepalive_timeout 10;
+  send_timeout 10s;
+  client_header_timeout 10s;
+  client_body_timeout 10s;
+  large_client_header_buffers 2 1k;
+  port_in_redirect off;
+  server_tokens off;
+
+  expires -1;
+
+  real_ip_header X-Forwarded-For;
+  set_real_ip_from 10.0.0.0/8;
+  set_real_ip_from 127.0.0.1/32;
+  set_real_ip_from 172.16.0.0/12;
+  set_real_ip_from 192.168.0.0/16;
+  real_ip_recursive on;
+
+  server {
+    listen {{ port }};
+    server_name localhost;
+
+    satisfy any;
+
+    error_page 403 = @forbidden;
+
+    location @forbidden {
+      allow all;
+      access_log off;
+
+      default_type text/plain;
+      return 403 'Forbidden by {{ env "APP_NAME" }}';
+    }
+
+    location @check {
+      default_type text/plain;
+      return 200 'OK';
+    }
+
+    location = /_route-service-health {
+      allow all;
+      access_log off;
+
+      stub_status on;
+      access_log off;
+    }
+
+    location = /_route-service-check {
+      allow 127.0.0.1/32;
+      {{env "ALLOWED_IPS"}}
+      deny all;
+
+      try_files $uri @check;
+    }
+
+    location / {
+      allow 127.0.0.1/32;
+      {{env "ALLOWED_IPS"}}
+      deny all;
+
+      resolver 169.254.0.2;
+
+      set $cf_forwarded_host '*';
+      set $cf_forwarded_uri '*';
+
+      if ($http_x_cf_forwarded_url ~* ^(https?\:\/\/)(.*?)\/(.*)$) {
+        set $cf_forwarded_host $2;
+        set $cf_forwarded_uri /$3;
+      }
+
+      proxy_http_version 1.1;
+      proxy_ssl_server_name on;
+      proxy_ssl_protocols TLSv1.2;
+      proxy_set_header Connection "";
+      proxy_set_header Host $cf_forwarded_host;
+      proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+
+      # Use XX-CF-APP-INSTANCE on the original request if you wish to target an instance
+      proxy_set_header X-CF-APP-INSTANCE $http_xx_cf_app_instance;
+
+      proxy_pass $http_x_forwarded_proto://$http_host$cf_forwarded_uri;
+    }
+  }
+}


### PR DESCRIPTION
## What?

Stub RP route service configuration.

Adds ability to restrict access to Stub RP instances depending on client IP address.

## Why?

This configuration will be used to deploy in the pipeline.  It has been tested by deploying to sandpit.

