### PR TITLE
AUT-386 - Add log4j2.xml

### DIFF
--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,12 @@
+<Configuration status="WARN">
+<Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+        <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+    </Console>
+</Appenders>
+<Loggers>
+    <Root level="error">
+        <AppenderRef ref="Console"/>
+    </Root>
+</Loggers>
+</Configuration>


### PR DESCRIPTION
## What?

 - Add log4j2.xml

## Why?

- To send logs to standard out
