### PR TITLE
AUT-386: gradle task to zip route service

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,4 +77,10 @@ run {
     }
 }
 
+task zipRouteService(type: Zip) {
+    from 'nginx/'
+    include '*'
+    archiveName 'di-auth-stub-rp-route-service.zip'
+}
+
 mainClassName = 'uk.gov.di.App'


### PR DESCRIPTION

## What?

Gradle task to zip route service

## Why?

Need to be able to get the route service from the github release.
'zip' command is not installed in the gradle image so using a gradle task instead.


