### PR TITLE
BAU - Make nonce mandatory in request object

### DIFF
--- a/src/main/java/uk/gov/di/utils/Oidc.java
+++ b/src/main/java/uk/gov/di/utils/Oidc.java
@@ -251,6 +251,7 @@ public class Oidc {
                         .claim("redirect_uri", callbackURL)
                         .claim("response_type", ResponseType.CODE.toString())
                         .claim("scope", scopes.toString())
+                        .claim("nonce", new Nonce().getValue())
                         .claim("client_id", this.clientId)
                         .claim("state", new State().getValue())
                         .issuer(this.clientId)


### PR DESCRIPTION
## What?

 - Make nonce mandatory in request object
 
## Why?

- We always expect the nonce mandatory in the request object
