### PR TITLE
AUT-549 - Parse the doc app credential as a list

### DIFF
--- a/src/main/java/uk/gov/di/handlers/AuthCallbackHandler.java
+++ b/src/main/java/uk/gov/di/handlers/AuthCallbackHandler.java
@@ -10,6 +10,7 @@ import uk.gov.di.utils.Oidc;
 import uk.gov.di.utils.ViewHelper;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Objects;
 
 public class AuthCallbackHandler implements Route {
@@ -36,7 +37,8 @@ public class AuthCallbackHandler implements Route {
         var model = new HashMap<>();
         var templateName = "userinfo.mustache";
         if (RelyingPartyConfig.clientType().equals("app")) {
-            model.put("doc_app_credential", userInfo.getClaim("doc-app-credential"));
+            List<String> docAppCredential = (List<String>) userInfo.getClaim("doc-app-credential");
+            model.put("doc_app_credential", docAppCredential.get(0));
             templateName = "doc-app-userinfo.mustache";
         } else {
             model.put("email", userInfo.getEmailAddress());


### PR DESCRIPTION
## What?

- Parse the doc app credential as a list

## Why?

- The Doc App Credential claim will now contain a list of JWTs instead of a single JWT. Update the Stub to reflect this.
- For the time being we will only receive one in the list, so for now just display the 1st JWT in the list and assume it is the only one.


