### PR TITLE
AUT-581: Remove logout button from doc app user info page

### DIFF
--- a/src/main/resources/templates/doc-app-userinfo.mustache
+++ b/src/main/resources/templates/doc-app-userinfo.mustache
@@ -89,9 +89,6 @@
                     </div>
                 </dl>
             </div>
-            <form action="/logout" method="post">
-                <button class="govuk-button" type="submit" name="logout">Log out</button>
-            </form>
         </div>
     </main>
 </div>


### PR DESCRIPTION

## What?

Remove logout button from doc app user info page.

## Why?

For the doc app journey the user is not actually logged in, so they cannot actually log out.
