### PR TITLE
AUT_590: Add ui_locales parameter for authorization

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v jq >/dev/null; then
+  echo "Must have JQ installed"
+  exit 1
+fi
+
+if [ -z "${ALLOWED_IPS+set}" ]; then
+  echo "Must set ALLOWED_IPS environment variable to a comma separated list of IP addresses"
+  exit 1
+fi
+
+if [ -z "${ROUTE_SERVICE_APP_NAME+set}" ]; then
+  echo "Must set ROUTE_SERVICE_APP_NAME environment variable"
+  exit 1
+fi
+
+if [ -z "${ROUTE_SERVICE_NAME+set}" ]; then
+  echo "Must set ROUTE_SERVICE_NAME environment variable"
+  exit 1
+fi
+
+if [ -z "${PROTECTED_APP_NAME+set}" ]; then
+  echo "Must set PROTECTED_APP_NAME environment variable"
+  exit 1
+fi
+
+IFS="," read -ra IPS <<< "$ALLOWED_IPS"
+
+NGINX_ALLOW_STATEMENTS=""
+for addr in "${IPS[@]}";
+  do NGINX_ALLOW_STATEMENTS="$NGINX_ALLOW_STATEMENTS \n allow $addr;"; true;
+done;
+
+APPS_DOMAIN=$(cf curl "/v3/domains" | jq -r '[.resources[] | select(.name|endswith("apps.digital"))][0].name')
+
+cf push "${ROUTE_SERVICE_APP_NAME}" --no-start --var app-name="${ROUTE_SERVICE_APP_NAME}"
+cf set-env "${ROUTE_SERVICE_APP_NAME}" ALLOWED_IPS "$(printf "%s" "${NGINX_ALLOW_STATEMENTS}")"
+cf start "${ROUTE_SERVICE_APP_NAME}"
+
+ROUTE_SERVICE_DOMAIN="$(cf curl "/v3/apps/$(cf app "${ROUTE_SERVICE_APP_NAME}" --guid)/routes" | jq -r --arg APPS_DOMAIN "${APPS_DOMAIN}" '[.resources[] | select(.url | endswith($APPS_DOMAIN))][0].url')"
+
+if cf curl "/v3/service_instances?type=user-provided&names=${ROUTE_SERVICE_NAME}" | jq -e '.pagination.total_results == 0' > /dev/null; then
+  cf create-user-provided-service \
+    "${ROUTE_SERVICE_NAME}" \
+    -r "https://${ROUTE_SERVICE_DOMAIN}";
+else
+  cf update-user-provided-service \
+    "${ROUTE_SERVICE_NAME}" \
+    -r "https://${ROUTE_SERVICE_DOMAIN}";
+fi
+
+PROTECTED_APP_HOSTNAME="$(cf curl "/v3/apps/$(cf app "${PROTECTED_APP_NAME}" --guid)/routes" | jq -r --arg APPS_DOMAIN "${APPS_DOMAIN}" '[.resources[] | select(.url | endswith($APPS_DOMAIN))][0].host')"
+
+cf bind-route-service "${APPS_DOMAIN}" "${ROUTE_SERVICE_NAME}" --hostname "${PROTECTED_APP_HOSTNAME}";

--- a/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
+++ b/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
@@ -98,9 +98,15 @@ public class AuthorizeHandler implements Route {
                 claimsSetRequest = claimsSetRequest.add(addressEntry);
             }
 
+            String language = formParameters.get("lng");
+
             var opURL =
                     oidcClient.buildAuthorizeRequest(
-                            RelyingPartyConfig.authCallbackUrl(), vtr, scopes, claimsSetRequest);
+                            RelyingPartyConfig.authCallbackUrl(),
+                            vtr,
+                            scopes,
+                            claimsSetRequest,
+                            language);
 
             LOG.info("Redirecting to OP");
             response.redirect(opURL);

--- a/src/main/java/uk/gov/di/utils/Oidc.java
+++ b/src/main/java/uk/gov/di/utils/Oidc.java
@@ -10,6 +10,8 @@ import com.nimbusds.jose.util.ResourceRetriever;
 import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.langtag.LangTag;
+import com.nimbusds.langtag.LangTagException;
 import com.nimbusds.oauth2.sdk.*;
 import com.nimbusds.oauth2.sdk.auth.JWTAuthenticationClaimsSet;
 import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
@@ -154,7 +156,11 @@ public class Oidc {
     }
 
     public String buildAuthorizeRequest(
-            String callbackUrl, String vtr, List<String> scopes, ClaimsSetRequest claimsSetRequest)
+            String callbackUrl,
+            String vtr,
+            List<String> scopes,
+            ClaimsSetRequest claimsSetRequest,
+            String language)
             throws URISyntaxException {
         LOG.info("Building Authorize Request");
         JSONArray jsonArray = new JSONArray();
@@ -175,6 +181,16 @@ public class Oidc {
             authorizationRequestBuilder.claims(
                     new OIDCClaimsRequest().withUserInfoClaimsRequest(claimsSetRequest));
         }
+
+        if (!language.isBlank()) {
+            try {
+                LOG.info("Adding ui_locales to Authorize Request {}", language);
+                authorizationRequestBuilder.uiLocales(List.of(LangTag.parse(language)));
+            } catch (LangTagException e) {
+                LOG.error("Unable to parse language {}", language);
+            }
+        }
+        ;
 
         return authorizationRequestBuilder.build().toURI().toString();
     }

--- a/src/main/resources/templates/home.mustache
+++ b/src/main/resources/templates/home.mustache
@@ -183,6 +183,42 @@
                     </fieldset>
                 </div>
 
+                <div class="govuk-grid-column-one-quarter govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                            <h3 class="govuk-fieldset__heading">
+                                Language (ui_locales)
+                            </h3>
+                        </legend>
+                        <div class="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="lng-none" name="lng" type="radio" value="" checked>
+                                <label class="govuk-label govuk-radios__label" for="lng-none">
+                                    none
+                                </label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="lng-en" name="lng" type="radio" value="en">
+                                <label class="govuk-label govuk-radios__label" for="lng-en">
+                                    English - en
+                                </label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="lng-cy" name="lng" type="radio" value="cy">
+                                <label class="govuk-label govuk-radios__label" for="lng-cy">
+                                    Welsh (Cymraeg) - cy
+                                </label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="lng-cy-AR" name="lng" type="radio" value="cy-AR">
+                                <label class="govuk-label govuk-radios__label" for="lng-cy-AR">
+                                    Welsh (Cymraeg) - Argentina - cy-AR
+                                </label>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+
                 <div class="govuk-grid-column-full">
                 <button data-prevent-double-click="true" class="govuk-button" id="govuk-signin-button" data-module="govuk-button" type="submit">
                     Continue


### PR DESCRIPTION
## What?

Add ui_locals parameter for authorization.
Includes radio buttons for choice of language.

RPs populate this field so although we only support en and cy as primary languages we need to be able to deal with extended tags too, the 'cy-AR' button is there for this purpose.  There is much more extensive testing of tag handling in the unit and integration tests in the corresponding backend change

## Why?

The RP should be able to request which language is used in Sign In.
Only supported languages can actually be chosen, fallback is English.

## Related

https://github.com/alphagov/di-authentication-api/pull/2292
