### PR TITLE
BAU show the core identity on return to the stub

### DIFF
--- a/src/main/java/uk/gov/di/handlers/AuthCallbackHandler.java
+++ b/src/main/java/uk/gov/di/handlers/AuthCallbackHandler.java
@@ -43,14 +43,16 @@ public class AuthCallbackHandler implements Route {
         } else {
             model.put("email", userInfo.getEmailAddress());
             model.put("phone_number", userInfo.getPhoneNumber());
-            boolean coreIdentityClaimPresent =
-                    Objects.nonNull(
-                            userInfo.getClaim("https://vocab.account.gov.uk/v1/coreIdentityJWT"));
+
+            var coreIdentityJWT = userInfo.getStringClaim("https://vocab.account.gov.uk/v1/coreIdentityJWT");
+            boolean coreIdentityClaimPresent = Objects.nonNull(coreIdentityJWT);
+            model.put("core_identity_claim_present", coreIdentityClaimPresent);
+            model.put("core_identity_claim", coreIdentityJWT);
+
             boolean addressClaimPresent =
                     Objects.nonNull(userInfo.getClaim("https://vocab.account.gov.uk/v1/address"));
             boolean passportClaimPresent =
                     Objects.nonNull(userInfo.getClaim("https://vocab.account.gov.uk/v1/passport"));
-            model.put("core_identity_claim_present", coreIdentityClaimPresent);
             model.put("address_claim_present", addressClaimPresent);
             model.put("passport_claim_present", passportClaimPresent);
         }

--- a/src/main/resources/templates/userinfo.mustache
+++ b/src/main/resources/templates/userinfo.mustache
@@ -97,6 +97,14 @@
                     </div>
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">
+                            Core Identity Claim
+                        </dt>
+                        <dd class="govuk-summary-list__value" id="user-info-core-identity-claim">
+                            {{core_identity_claim}}
+                        </dd>
+                    </div>
+                    <div class="govuk-summary-list__row">
+                        <dt class="govuk-summary-list__key">
                             Address Claim Present
                         </dt>
                         <dd class="govuk-summary-list__value" id="user-info-address-claim">


### PR DESCRIPTION
## What?

Modifies `AuthCallBackHandler` and `userinfo.mustache` to show the content of the core identity claim.

## Why?

We'd like to see the identity that SPOT issues.

## Testing

I've actually no idea how we test this - would be good to discus with someone from Auth.