### PR TITLE
BAU: Validate CoreIdentity JWT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ example-clients/python/app/*.pyc
 example-clients/python/app/__pycache__
 .env
 .java-version
+out/

--- a/src/main/java/uk/gov/di/OidcRp.java
+++ b/src/main/java/uk/gov/di/OidcRp.java
@@ -8,6 +8,7 @@ import uk.gov.di.handlers.ErrorHandler;
 import uk.gov.di.handlers.HomeHandler;
 import uk.gov.di.handlers.SignOutHandler;
 import uk.gov.di.handlers.SignedOutHandler;
+import uk.gov.di.utils.CoreIdentityValidator;
 import uk.gov.di.utils.Oidc;
 import uk.gov.di.utils.PrivateKeyReader;
 
@@ -36,7 +37,8 @@ public class OidcRp {
 
         var homeHandler = new HomeHandler();
         var authorizeHandler = new AuthorizeHandler(oidcClient);
-        var authCallbackHandler = new AuthCallbackHandler(oidcClient);
+        var authCallbackHandler =
+                new AuthCallbackHandler(oidcClient, CoreIdentityValidator.createValidator());
         var logoutHandler = new SignOutHandler(oidcClient);
         var signedOutHandler = new SignedOutHandler();
         var errorHandler = new ErrorHandler();

--- a/src/main/java/uk/gov/di/config/RelyingPartyConfig.java
+++ b/src/main/java/uk/gov/di/config/RelyingPartyConfig.java
@@ -2,8 +2,11 @@ package uk.gov.di.config;
 
 import io.pivotal.cfenv.core.CfEnv;
 
+import java.util.Optional;
+
 import static java.lang.System.getenv;
 import static java.text.MessageFormat.format;
+import static java.util.function.Predicate.not;
 
 public class RelyingPartyConfig {
 
@@ -19,6 +22,12 @@ public class RelyingPartyConfig {
 
     public static String clientPrivateKey() {
         return configValue("CLIENT_PRIVATE_KEY", "PRIVATE-KEY");
+    }
+
+    public static Optional<String> identitySigningPublicKey() {
+        return Optional.of(getenv())
+                .map(env -> env.get("IDENTITY_SIGNING_PUBLIC_KEY"))
+                .filter(not(String::isBlank));
     }
 
     public static String accountManagementUrl() {

--- a/src/main/java/uk/gov/di/handlers/AuthCallbackHandler.java
+++ b/src/main/java/uk/gov/di/handlers/AuthCallbackHandler.java
@@ -6,6 +6,7 @@ import spark.Request;
 import spark.Response;
 import spark.Route;
 import uk.gov.di.config.RelyingPartyConfig;
+import uk.gov.di.utils.CoreIdentityValidator;
 import uk.gov.di.utils.Oidc;
 import uk.gov.di.utils.ViewHelper;
 
@@ -17,10 +18,12 @@ public class AuthCallbackHandler implements Route {
 
     private static final Logger LOG = LoggerFactory.getLogger(AuthCallbackHandler.class);
 
-    private Oidc oidcClient;
+    private final Oidc oidcClient;
+    private final CoreIdentityValidator validator;
 
-    public AuthCallbackHandler(Oidc oidc) {
+    public AuthCallbackHandler(Oidc oidc, CoreIdentityValidator validator) {
         this.oidcClient = oidc;
+        this.validator = validator;
     }
 
     @Override

--- a/src/main/java/uk/gov/di/handlers/AuthCallbackHandler.java
+++ b/src/main/java/uk/gov/di/handlers/AuthCallbackHandler.java
@@ -47,10 +47,15 @@ public class AuthCallbackHandler implements Route {
             model.put("email", userInfo.getEmailAddress());
             model.put("phone_number", userInfo.getPhoneNumber());
 
-            var coreIdentityJWT = userInfo.getStringClaim("https://vocab.account.gov.uk/v1/coreIdentityJWT");
+            var coreIdentityJWT =
+                    userInfo.getStringClaim("https://vocab.account.gov.uk/v1/coreIdentityJWT");
             boolean coreIdentityClaimPresent = Objects.nonNull(coreIdentityJWT);
             model.put("core_identity_claim_present", coreIdentityClaimPresent);
             model.put("core_identity_claim", coreIdentityJWT);
+
+            if (coreIdentityClaimPresent) {
+                model.put("core_identity_claim_signature", validator.isValid(coreIdentityJWT));
+            }
 
             boolean addressClaimPresent =
                     Objects.nonNull(userInfo.getClaim("https://vocab.account.gov.uk/v1/address"));

--- a/src/main/java/uk/gov/di/utils/CoreIdentityValidator.java
+++ b/src/main/java/uk/gov/di/utils/CoreIdentityValidator.java
@@ -1,5 +1,7 @@
 package uk.gov.di.utils;
 
+import uk.gov.di.config.RelyingPartyConfig;
+
 public class CoreIdentityValidator {
 
     public enum Result {
@@ -7,10 +9,25 @@ public class CoreIdentityValidator {
     }
 
     public static CoreIdentityValidator createValidator() {
-        return new CoreIdentityValidator();
+        return RelyingPartyConfig.identitySigningPublicKey()
+                .map(CoreIdentityValidator::new)
+                .orElse(new NoopCoreIdentityValidator());
     }
+
+    private CoreIdentityValidator(Object jwt) {}
 
     public Result isValid(String jwt) {
         return Result.NOT_VALIDATED;
+    }
+
+    static class NoopCoreIdentityValidator extends CoreIdentityValidator {
+        private NoopCoreIdentityValidator() {
+            super(null);
+        }
+
+        @Override
+        public Result isValid(String jwt) {
+            return Result.NOT_VALIDATED;
+        }
     }
 }

--- a/src/main/java/uk/gov/di/utils/CoreIdentityValidator.java
+++ b/src/main/java/uk/gov/di/utils/CoreIdentityValidator.java
@@ -1,10 +1,13 @@
 package uk.gov.di.utils;
 
 import com.nimbusds.jose.Algorithm;
+import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.crypto.ECDSAVerifier;
 import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jwt.SignedJWT;
 import uk.gov.di.config.RelyingPartyConfig;
 
 import java.security.KeyFactory;
@@ -12,6 +15,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
+import java.text.ParseException;
 import java.util.Base64;
 import java.util.Optional;
 
@@ -20,6 +24,8 @@ public class CoreIdentityValidator {
     private final ECKey key;
 
     public enum Result {
+        VALID,
+        INVALID,
         NOT_VALIDATED
     }
 
@@ -53,7 +59,13 @@ public class CoreIdentityValidator {
     }
 
     public Result isValid(String jwt) {
-        return Result.NOT_VALIDATED;
+        try {
+            return SignedJWT.parse(jwt).verify(new ECDSAVerifier(this.key))
+                    ? Result.VALID
+                    : Result.INVALID;
+        } catch (JOSEException | ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     static class NoopCoreIdentityValidator extends CoreIdentityValidator {

--- a/src/main/java/uk/gov/di/utils/CoreIdentityValidator.java
+++ b/src/main/java/uk/gov/di/utils/CoreIdentityValidator.java
@@ -1,8 +1,23 @@
 package uk.gov.di.utils;
 
+import com.nimbusds.jose.Algorithm;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.KeyUse;
 import uk.gov.di.config.RelyingPartyConfig;
 
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+import java.util.Optional;
+
 public class CoreIdentityValidator {
+
+    private final ECKey key;
 
     public enum Result {
         NOT_VALIDATED
@@ -10,11 +25,32 @@ public class CoreIdentityValidator {
 
     public static CoreIdentityValidator createValidator() {
         return RelyingPartyConfig.identitySigningPublicKey()
+                .map(Base64.getDecoder()::decode)
+                .map(X509EncodedKeySpec::new)
+                .flatMap(
+                        spec -> {
+                            try {
+                                return Optional.ofNullable(
+                                        KeyFactory.getInstance("EC").generatePublic(spec));
+                            } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+                                e.printStackTrace();
+                                return Optional.empty();
+                            }
+                        })
+                .map(ECPublicKey.class::cast)
+                .map(
+                        key ->
+                                new ECKey.Builder(Curve.P_256, key)
+                                        .keyUse(KeyUse.SIGNATURE)
+                                        .algorithm(new Algorithm(JWSAlgorithm.ES256.getName()))
+                                        .build())
                 .map(CoreIdentityValidator::new)
                 .orElse(new NoopCoreIdentityValidator());
     }
 
-    private CoreIdentityValidator(Object jwt) {}
+    private CoreIdentityValidator(ECKey key) {
+        this.key = key;
+    }
 
     public Result isValid(String jwt) {
         return Result.NOT_VALIDATED;

--- a/src/main/java/uk/gov/di/utils/CoreIdentityValidator.java
+++ b/src/main/java/uk/gov/di/utils/CoreIdentityValidator.java
@@ -1,0 +1,16 @@
+package uk.gov.di.utils;
+
+public class CoreIdentityValidator {
+
+    public enum Result {
+        NOT_VALIDATED
+    }
+
+    public static CoreIdentityValidator createValidator() {
+        return new CoreIdentityValidator();
+    }
+
+    public Result isValid(String jwt) {
+        return Result.NOT_VALIDATED;
+    }
+}

--- a/src/main/resources/templates/userinfo.mustache
+++ b/src/main/resources/templates/userinfo.mustache
@@ -95,6 +95,16 @@
                             {{core_identity_claim_present}}
                         </dd>
                     </div>
+                    {{#core_identity_claim_signature}}
+                    <div class="govuk-summary-list__row">
+                        <dt class="govuk-summary-list__key">
+                            Core Identity Claim Signature Valid
+                        </dt>
+                        <dd class="govuk-summary-list__value" id="user-info-core-identity-claim-valid">
+                            {{core_identity_claim_signature}}
+                        </dd>
+                    </div>
+                    {{/core_identity_claim_signature}}
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">
                             Core Identity Claim


### PR DESCRIPTION
The stub reads the CoreIdentity JWT from `/userinfo` if present but does not validate the signature.

This PR creates an environment variable, for the signing key, which if present will be used to check the signature on the JWT and output its validity.
