### PR TITLE
BAU: Refactorings (`Oidc`)

### DIFF
--- a/src/main/java/uk/gov/di/config/RelyingPartyConfig.java
+++ b/src/main/java/uk/gov/di/config/RelyingPartyConfig.java
@@ -1,5 +1,6 @@
 package uk.gov.di.config;
 
+import com.nimbusds.jose.JWSAlgorithm;
 import io.pivotal.cfenv.core.CfEnv;
 
 import java.util.Optional;
@@ -42,6 +43,10 @@ public class RelyingPartyConfig {
 
     public static String clientType() {
         return configValue("CLIENT_TYPE", "web");
+    }
+
+    public static JWSAlgorithm idTokenSigningAlgorithm() {
+        return JWSAlgorithm.parse(configValue("ID_TOKEN_SIGNING_ALGORITHM", "ES256"));
     }
 
     public static String serviceName() {

--- a/src/main/java/uk/gov/di/utils/Oidc.java
+++ b/src/main/java/uk/gov/di/utils/Oidc.java
@@ -41,6 +41,7 @@ import net.minidev.json.JSONArray;
 import org.apache.http.client.utils.URIBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.di.config.RelyingPartyConfig;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -243,13 +244,12 @@ public class Oidc {
         LOG.info("Validating ID token");
         var iss = new Issuer(this.providerMetadata.getIssuer());
         var clientID = new ClientID(this.clientId);
-        var jwsAlg = this.providerMetadata.getIDTokenJWSAlgs().get(0);
         ResourceRetriever resourceRetriever = new DefaultResourceRetriever(30000, 30000);
         var idTokenValidator =
                 new IDTokenValidator(
                         iss,
                         clientID,
-                        jwsAlg,
+                        RelyingPartyConfig.idTokenSigningAlgorithm(),
                         this.providerMetadata.getJWKSetURI().toURL(),
                         resourceRetriever);
 
@@ -265,12 +265,11 @@ public class Oidc {
         try {
             var iss = new Issuer(this.providerMetadata.getIssuer());
             var clientID = new ClientID(this.clientId);
-            var jwsAlg = this.providerMetadata.getIDTokenJWSAlgs().get(0);
             var validator =
                     new LogoutTokenValidator(
                             iss,
                             clientID,
-                            jwsAlg,
+                            RelyingPartyConfig.idTokenSigningAlgorithm(),
                             this.providerMetadata.getJWKSetURI().toURL(),
                             new DefaultResourceRetriever(30000, 30000));
 

--- a/src/main/java/uk/gov/di/utils/Oidc.java
+++ b/src/main/java/uk/gov/di/utils/Oidc.java
@@ -196,7 +196,6 @@ public class Oidc {
                 LOG.error("Unable to parse language {}", language);
             }
         }
-        ;
 
         return authorizationRequestBuilder.build().toURI().toString();
     }

--- a/src/main/java/uk/gov/di/utils/Oidc.java
+++ b/src/main/java/uk/gov/di/utils/Oidc.java
@@ -228,11 +228,10 @@ public class Oidc {
 
     public void validateIdToken(JWT idToken) throws MalformedURLException {
         LOG.info("Validating ID token");
-        var iss = new Issuer(this.providerMetadata.getIssuer());
         ResourceRetriever resourceRetriever = new DefaultResourceRetriever(30000, 30000);
         var idTokenValidator =
                 new IDTokenValidator(
-                        iss,
+                        this.providerMetadata.getIssuer(),
                         this.clientId,
                         RelyingPartyConfig.idTokenSigningAlgorithm(),
                         this.providerMetadata.getJWKSetURI().toURL(),
@@ -248,10 +247,9 @@ public class Oidc {
 
     public Optional<LogoutTokenClaimsSet> validateLogoutToken(JWT logoutToken) {
         try {
-            var iss = new Issuer(this.providerMetadata.getIssuer());
             var validator =
                     new LogoutTokenValidator(
-                            iss,
+                            this.providerMetadata.getIssuer(),
                             this.clientId,
                             RelyingPartyConfig.idTokenSigningAlgorithm(),
                             this.providerMetadata.getJWKSetURI().toURL(),


### PR DESCRIPTION
- BAU: Parametrise expected id token signing algorithm
- BAU: Use built-in method to read metadata from baseurl
- BAU: Make clientId field actually a `ClientID`
- BAU: Use issuer directly off metadata
- BAU: Sign authorization and token JWTs with same method
- BAU: Remove extraaneous semicolon
