### PR TITLE
AUT-805: Show 'locale' claim on user-info screen

### DIFF
--- a/src/main/java/uk/gov/di/handlers/AuthCallbackHandler.java
+++ b/src/main/java/uk/gov/di/handlers/AuthCallbackHandler.java
@@ -62,10 +62,12 @@ public class AuthCallbackHandler implements Route {
             boolean passportClaimPresent =
                     Objects.nonNull(userInfo.getClaim("https://vocab.account.gov.uk/v1/passport"));
             boolean drivingPermitClaimPresent =
-                    Objects.nonNull(userInfo.getClaim("https://vocab.account.gov.uk/v1/drivingPermit"));
+                    Objects.nonNull(
+                            userInfo.getClaim("https://vocab.account.gov.uk/v1/drivingPermit"));
             model.put("address_claim_present", addressClaimPresent);
             model.put("passport_claim_present", passportClaimPresent);
             model.put("driving_permit_claim_present", drivingPermitClaimPresent);
+            model.put("locale_claim", userInfo.getClaim("locale"));
         }
         model.put("my_account_url", RelyingPartyConfig.accountManagementUrl());
         model.put("id_token", tokens.getIDToken().getParsedString());

--- a/src/main/resources/templates/userinfo.mustache
+++ b/src/main/resources/templates/userinfo.mustache
@@ -149,7 +149,7 @@
                         <dt class="govuk-summary-list__key">
                             Locale claim
                         </dt>
-                        <dd class="govuk-summary-list__value" id="user-info-phone-number">
+                        <dd class="govuk-summary-list__value" id="user-info-locale">
                             {{locale_claim}}
                         </dd>
                     </div>

--- a/src/main/resources/templates/userinfo.mustache
+++ b/src/main/resources/templates/userinfo.mustache
@@ -145,6 +145,14 @@
                             {{id_token}}
                         </dd>
                     </div>
+                    <div class="govuk-summary-list__row">
+                        <dt class="govuk-summary-list__key">
+                            Locale claim
+                        </dt>
+                        <dd class="govuk-summary-list__value" id="user-info-phone-number">
+                            {{locale_claim}}
+                        </dd>
+                    </div>
                 </dl>
             </div>
             <form action="/logout" method="post">

--- a/startup.sh
+++ b/startup.sh
@@ -4,5 +4,7 @@ set -eu
 echo "Building DI authentication Stub relying party"
 ./gradlew clean build
 
+export $(grep -v '^#' .env | xargs)
+
 echo "Starting DI authentication Stub relying party"
 ./gradlew run


### PR DESCRIPTION
## What?

Show 'locale' claim on user-info screen.

See section '5.1.  Standard Claims':

https://openid.net/specs/openid-connect-core-1_0.html

## Why?

'locale' is a standard claim indicating the end-user's locale.
Added to the stub to enable testing when providing this claim is added to the oidc api.

## Related PRs

