### PR TITLE
BAU: Handle trailing '/' on op_base_url for logout

### DIFF
--- a/src/main/java/uk/gov/di/utils/Oidc.java
+++ b/src/main/java/uk/gov/di/utils/Oidc.java
@@ -214,7 +214,9 @@ public class Oidc {
 
     public String buildLogoutUrl(String idToken, String state, String postLogoutRedirectUri)
             throws URISyntaxException {
-        var logoutUri = new URIBuilder(this.idpUrl + "/logout");
+        var logoutUri =
+                new URIBuilder(this.idpUrl + (this.idpUrl.endsWith("/") ? "logout" : "/logout"));
+        System.out.println(logoutUri);
         logoutUri.addParameter("id_token_hint", idToken);
         logoutUri.addParameter("state", state);
         logoutUri.addParameter("post_logout_redirect_uri", postLogoutRedirectUri);


### PR DESCRIPTION
## What?

Handle trailing '/' on op_base_url for logout.

## Why?

A trailing '/' was added to the op_base_url to support refactoring changes, however this has broken the logout link.

## Related PRs

https://github.com/alphagov/di-infrastructure/pull/428
#189 
