### PR TITLE
BAU: Send clientId value in the doc app request object

### DIFF
--- a/src/main/java/uk/gov/di/utils/Oidc.java
+++ b/src/main/java/uk/gov/di/utils/Oidc.java
@@ -268,7 +268,7 @@ public class Oidc {
                         .claim("response_type", ResponseType.CODE.toString())
                         .claim("scope", scopes.toString())
                         .claim("nonce", new Nonce().getValue())
-                        .claim("client_id", this.clientId)
+                        .claim("client_id", this.clientId.getValue())
                         .claim("state", new State().getValue())
                         .claim("ui_locales", language)
                         .issuer(this.clientId.getValue())


### PR DESCRIPTION

## What?

Send clientId value in the doc app request object.

## Why?

Following on from OIDC refactorings in the stub, the doc app journey in build is failing with 'unauthorized_client' as the client id value is not being passed in the request object.

## Related PRs

#192 
#189 
https://github.com/alphagov/di-infrastructure/pull/428

