### PR TITLE
BAU: buildLogoutUri refactoring 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ example-clients/python/app/__pycache__
 .env
 .java-version
 out/
+bin/

--- a/deploy-sandpit.sh
+++ b/deploy-sandpit.sh
@@ -60,6 +60,7 @@ app_name: ${CLIENT_NAME}
 service_name: "Sample Service - Sandpit"
 client_type: WEB
 environment_name: sandpit
+identity_signing_public_key: anykey
 EOF
 popd > /dev/null
 echo "done!"

--- a/src/main/java/uk/gov/di/utils/Oidc.java
+++ b/src/main/java/uk/gov/di/utils/Oidc.java
@@ -214,14 +214,13 @@ public class Oidc {
 
     public String buildLogoutUrl(String idToken, String state, String postLogoutRedirectUri)
             throws URISyntaxException {
-        var logoutUri =
-                new URIBuilder(this.idpUrl + (this.idpUrl.endsWith("/") ? "logout" : "/logout"));
-        System.out.println(logoutUri);
-        logoutUri.addParameter("id_token_hint", idToken);
-        logoutUri.addParameter("state", state);
-        logoutUri.addParameter("post_logout_redirect_uri", postLogoutRedirectUri);
-
-        return logoutUri.build().toString();
+        return new URIBuilder()
+                .setHost(this.idpUrl)
+                .setPath("logout")
+                .addParameter("id_token_hint", idToken)
+                .addParameter("state", state)
+                .addParameter("post_logout_redirect_uri", postLogoutRedirectUri)
+                .toString();
     }
 
     public void validateIdToken(JWT idToken) throws MalformedURLException {


### PR DESCRIPTION
## What?

'buildLogoutUri' refactoring.
Remove 'System.out'.
Git ignore and deploy sandpit tweaks.

## Why?

A more elegant way to build the logout uri.

## Related PRs

#192 
