### PR TITLE
BAU: Update oidc base url after sandpit dns changes

### DIFF
--- a/deploy-sandpit.sh
+++ b/deploy-sandpit.sh
@@ -52,7 +52,7 @@ pushd "${API_DIR}/ci/terraform/shared" > /dev/null
 PRIVATE_KEY="$(terraform output -json | jq -r 'first(.stub_rp_client_credentials.value[] | select (.client_name == $client_name)).private_key' --arg client_name "${CLIENT_NAME}")"
 
 cat <<EOF > "/tmp/sandpit-vars.yml"
-op_base_url: https://api.sandpit.auth.ida.digital.cabinet-office.gov.uk
+op_base_url: https://oidc.sandpit.account.gov.uk/
 am_url: https://account-managment..sandpit.auth.ida.digital.cabinet-office.gov.uk
 client_private_key: $(echo "${PRIVATE_KEY}" | openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt | jq -sR)
 client_id: $(terraform output -json | jq 'first(.stub_rp_client_credentials.value[] | select (.client_name == $client_name)).client_id' --arg client_name "${CLIENT_NAME}")


### PR DESCRIPTION
## What?

Update oidc base url after sandpit dns changes.

## Why?

Sandpit domain names have been updated to follow the pattern used by the other environments.
