### PR TITLE
AUT-1138: Reduce stub app memory limit

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,7 @@
 applications:
   - name: ((app_name))
     path: build/distributions/di-auth-stub-relying-party.zip
-    memory: 1G
+    memory: 512M
     buildpacks:
       - https://github.com/cloudfoundry/java-buildpack.git#v4.48.3
     command: cd di-auth-stub-relying-party && bin/di-auth-stub-relying-party


### PR DESCRIPTION
## What?

Reduce stub app memory limit.

## Why?

Stubs are currently only consuming around 100M so lowering the limit to save memory (with a view to adding additional stubs).
