### PR TITLE
AUT-1836: fixed unsafe dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,18 +26,20 @@ repositories {
 }
 
 dependencies {
-    implementation "com.sparkjava:spark-core:2.9.3",
+    implementation "com.sparkjava:spark-core:2.9.4",
             "com.sparkjava:spark-template-mustache:2.7.1",
             "com.nimbusds:oauth2-oidc-sdk:9.37.2",
             "org.slf4j:slf4j-simple:1.7.36",
             "org.apache.httpcomponents:httpclient:4.5.13",
             "io.pivotal.cfenv:java-cfenv:2.4.0",
-
-            implementation('org.eclipse.jetty:jetty-server') {
-                version {
-                    strictly '9.4.43.v20210629'
-                }
-            }
+            'org.eclipse.jetty:jetty-xml:12.0.2',
+            'net.minidev:json-smart:2.5.0',
+            'com.fasterxml.jackson.core:jackson-databind:2.15.3'
+    implementation('org.eclipse.jetty:jetty-server') {
+        version {
+            strictly '12.0.2'
+        }
+    }
 
     testImplementation "junit:junit:4.13.2"
 }


### PR DESCRIPTION
## What?

Updated jetty-server dependency to 12.0.2. Also added current jetty-xml, json-smart and jackson-databind dependencies

## Why?

Jetty server dependency needed to be updated to address vulnerability identified in IT health check. Other dependencies were added to address vulnerabilities identified by Checkmarx
