### PR TITLE
Revert "AUT-1836: fixed unsafe dependencies"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,20 +26,18 @@ repositories {
 }
 
 dependencies {
-    implementation "com.sparkjava:spark-core:2.9.4",
+    implementation "com.sparkjava:spark-core:2.9.3",
             "com.sparkjava:spark-template-mustache:2.7.1",
             "com.nimbusds:oauth2-oidc-sdk:9.37.2",
             "org.slf4j:slf4j-simple:1.7.36",
             "org.apache.httpcomponents:httpclient:4.5.13",
             "io.pivotal.cfenv:java-cfenv:2.4.0",
-            'org.eclipse.jetty:jetty-xml:12.0.2',
-            'net.minidev:json-smart:2.5.0',
-            'com.fasterxml.jackson.core:jackson-databind:2.15.3'
-    implementation('org.eclipse.jetty:jetty-server') {
-        version {
-            strictly '12.0.2'
-        }
-    }
+
+            implementation('org.eclipse.jetty:jetty-server') {
+                version {
+                    strictly '9.4.43.v20210629'
+                }
+            }
 
     testImplementation "junit:junit:4.13.2"
 }


### PR DESCRIPTION
This reverts commit f99b9543fe767abecfd3b7793cc9b9e8aaee33bd.
This change causes the app to crash on launch with the following stacktrace:
```
Exception in thread "Thread-0" java.lang.NoClassDefFoundError: org/eclipse/jetty/server/session/SessionHandler
        at java.base/java.lang.ClassLoader.defineClass1(Native Method)
        at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1017)
        at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:150)
        at java.base/jdk.internal.loader.BuiltinClassLoader.defineClass(BuiltinClassLoader.java:862)
        at java.base/jdk.internal.loader.BuiltinClassLoader.findClassOnClassPathOrNull(BuiltinClassLoader.java:760)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:681)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:639)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
        at spark.embeddedserver.jetty.EmbeddedJettyFactory.create(EmbeddedJettyFactory.java:51)
        at spark.embeddedserver.EmbeddedServers.create(EmbeddedServers.java:80)
        at spark.Service.lambda$init$2(Service.java:624)
        at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.ClassNotFoundException: org.eclipse.jetty.server.session.SessionHandler
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
        ... 13 more
```

## Related PRs
#238 
