### PR TITLE
AUT-1836: addressed dependency vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,13 +32,13 @@ dependencies {
             "org.slf4j:slf4j-simple:1.7.36",
             "org.apache.httpcomponents:httpclient:4.5.13",
             "io.pivotal.cfenv:java-cfenv:2.4.0",
-
+            'net.minidev:json-smart:2.5.0',
+            'com.fasterxml.jackson.core:jackson-databind:2.15.3',
             implementation('org.eclipse.jetty:jetty-server') {
                 version {
-                    strictly '9.4.43.v20210629'
+                    strictly '10.0.17'
                 }
             }
-
     testImplementation "junit:junit:4.13.2"
 }
 


### PR DESCRIPTION
## What?

Addressed vulnerabilities in dependencies. Chose version 10.0.17 for jetty-server as this is compatible with spark-core 2.9.3 and I believe this is what broke the deployment in di-auth-stub-relying-party/pull/238, and this version has no vulnerabilities according to maven:

https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-server

Also added dependencies for json-smart and jackson-databind.

## Why?

To address dependency vulnerabilities and ensure dependencies are compatible with one another.
Json-smart and jackson-databind dependencies were added to address vulnerabilities identified by checkmarx when making these changes.

## Related PRs

https://github.com/alphagov/di-auth-stub-relying-party/pull/240
https://github.com/alphagov/di-auth-stub-relying-party/pull/238
