### PR TITLE
AUT-1837: fixed verbose response header

### DIFF
--- a/src/main/java/uk/gov/di/handlers/ErrorHandler.java
+++ b/src/main/java/uk/gov/di/handlers/ErrorHandler.java
@@ -22,6 +22,7 @@ public class ErrorHandler implements Route {
         var model = new HashMap<>();
         model.put("error", request.queryParams("error"));
         model.put("error_description", request.queryParams("error_description"));
+        response.header("Server", "govuk-sign-in-stub-rp");
         return ViewHelper.render(model, "error.mustache");
     }
 }


### PR DESCRIPTION
## What?
Set "Server" response heading value to "govuk-sign-in-stub-rp" when response status is 500

## Why?

This is to prevent responses from containing information that allows for identification of technologies used and potential exploits. The ITHC identified an issue with the jetty version being shown in responses as vulnerable.

The ITHC recommended solution of implementing a start.ini file containing `jetty.httpConfig.sendServerVersion=false` would not work with the current build as jetty-server embedded with spark does accept configuration in that way. 

The problem was only identified in responses with status 500. As 500 response codes are only handled by the ErrorHandler.java file, a different "Server" header value of "govuk-sign-in-stub-rp" was assigned in the handle method to match that of other responses.
