### PR TITLE
ATO-21: Request object flow in stubs (auth-only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ logs/
 .project
 .settings/
 bin/
+*.pem

--- a/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
+++ b/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
@@ -52,7 +52,7 @@ public class AuthorizeHandler implements Route {
                 LOG.info("Doc Checking App journey initialized");
                 scopes.add("doc-checking-app");
                 var opURL =
-                        oidcClient.buildSecureAuthorizeRequest(
+                        oidcClient.buildDocAppAuthorizeRequest(
                                 RelyingPartyConfig.authCallbackUrl(),
                                 Scope.parse(scopes),
                                 language);

--- a/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
+++ b/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
@@ -124,7 +124,7 @@ public class AuthorizeHandler implements Route {
             }
 
             var opURL =
-                    oidcClient.buildAuthorizeRequest(
+                    oidcClient.buildQueryParamAuthorizeRequest(
                             RelyingPartyConfig.authCallbackUrl(),
                             vtr,
                             scopes,

--- a/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
+++ b/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
@@ -123,6 +123,20 @@ public class AuthorizeHandler implements Route {
                 claimsSetRequest = claimsSetRequest.add(socialSecurityRecordEntry);
             }
 
+            if ("object".equals(formParameters.getOrDefault("request", "query"))) {
+                LOG.info("Using signed request object for /authorize request");
+                var redirectUrl =
+                        oidcClient.buildJarAuthorizeRequest(
+                                RelyingPartyConfig.authCallbackUrl(),
+                                vtr,
+                                scopes,
+                                claimsSetRequest,
+                                language,
+                                prompt);
+                response.redirect(redirectUrl.toURI().toString());
+                return null;
+            }
+
             var opURL =
                     oidcClient.buildQueryParamAuthorizeRequest(
                             RelyingPartyConfig.authCallbackUrl(),

--- a/src/main/java/uk/gov/di/utils/Oidc.java
+++ b/src/main/java/uk/gov/di/utils/Oidc.java
@@ -205,7 +205,7 @@ public class Oidc {
         return this.providerMetadata.getAuthorizationEndpointURI().toString();
     }
 
-    public String buildSecureAuthorizeRequest(String callbackUrl, Scope scopes, String language) {
+    public String buildDocAppAuthorizeRequest(String callbackUrl, Scope scopes, String language) {
         LOG.info("Building secure Authorize Request");
         var authRequestBuilder =
                 new AuthorizationRequest.Builder(

--- a/src/main/java/uk/gov/di/utils/Oidc.java
+++ b/src/main/java/uk/gov/di/utils/Oidc.java
@@ -153,7 +153,7 @@ public class Oidc {
         }
     }
 
-    public AuthenticationRequest buildAuthorizeRequest(
+    public AuthenticationRequest buildQueryParamAuthorizeRequest(
             String callbackUrl,
             String vtr,
             List<String> scopes,

--- a/src/main/java/uk/gov/di/utils/Oidc.java
+++ b/src/main/java/uk/gov/di/utils/Oidc.java
@@ -195,7 +195,7 @@ public class Oidc {
         }
 
         return new AuthenticationRequest.Builder(
-                        ResponseType.CODE, Scope.parse(scopes), this.clientId, new URI(callbackUrl))
+                        ResponseType.CODE, Scope.parse(scopes), this.clientId, null)
                 .endpointURI(this.providerMetadata.getAuthorizationEndpointURI())
                 .requestObject(signJwtWithClaims(requestObject.build()))
                 .build();

--- a/src/main/resources/templates/home.mustache
+++ b/src/main/resources/templates/home.mustache
@@ -277,6 +277,29 @@
                         </div>
                     </fieldset>
                 </div>
+                <div class="govuk-grid-column-one-quarter govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                            <h3 class="govuk-fieldset__heading">
+                                Request Method
+                            </h3>
+                        </legend>
+                        <div class="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="request-query-params" name="request" type="radio" value="query" checked>
+                                <label class="govuk-label govuk-radios__label" for="request-query-params">
+                                    Query Parameters
+                                </label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="request-object" name="request" type="radio" value="object">
+                                <label class="govuk-label govuk-radios__label" for="request-query-params">
+                                    Request Object
+                                </label>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
 
                 <div class="govuk-grid-column-full">
                 <button data-prevent-double-click="true" class="govuk-button" id="govuk-signin-button" data-module="govuk-button" type="submit">

--- a/src/main/resources/templates/post-page.mustache
+++ b/src/main/resources/templates/post-page.mustache
@@ -129,6 +129,14 @@
                             <input class="govuk-input" id="client_id" name="client_id" type="text" value="{{client_id}}" readonly>
                         </dd>
                     </div>
+                    <div class="govuk-summary-list__row">
+                        <dt class="govuk-summary-list__key">
+                            request
+                        </dt>
+                        <dd class="govuk-summary-list__value">
+                            <input class="govuk-input" id="request" name="request" type="text" value="{{request}}" readonly>
+                        </dd>
+                    </div>
                 </dl>
 
                 <div class="govuk-grid-column-full">


### PR DESCRIPTION
## What?

This PR adds capability to the stub to optionally run flows using request objects (JAR) rather than query parameters in the authorisation request to GOV.UK One Login

## Why?

We can test and demonstrate the matrix of flows that our API supports

