### PR TITLE
ATO-202: Properly serialise `vtr` as a field rather than a serialised string

### DIFF
--- a/src/main/java/uk/gov/di/utils/Oidc.java
+++ b/src/main/java/uk/gov/di/utils/Oidc.java
@@ -180,7 +180,7 @@ public class Oidc {
                         .claim("nonce", new Nonce().getValue())
                         .claim("client_id", this.clientId.getValue())
                         .claim("state", new State().getValue())
-                        .claim("vtr", jsonArray.toJSONString())
+                        .claim("vtr", jsonArray)
                         .claim("claims", claimsSetRequest.toJSONString())
                         .claim("prompt", authRequestPrompt.toString())
                         .issuer(this.clientId.getValue());


### PR DESCRIPTION
This serialises the `vtr` field on request objects as a list rather than as a stringified list, in accordance with the JWT spec

Before:

```
{
  ...
  "vtr": "[\"Cl.Cm\"]"
  ...
}
```

After:

```
{
  ...
  "vtr": [
    "Cl.Cm"
  ]
  ...
}
```
