### PR TITLE
ATO-242: Update stub to support Return Code claim

### DIFF
--- a/src/main/java/uk/gov/di/handlers/AuthCallbackHandler.java
+++ b/src/main/java/uk/gov/di/handlers/AuthCallbackHandler.java
@@ -52,10 +52,14 @@ public class AuthCallbackHandler implements Route {
             boolean coreIdentityClaimPresent = Objects.nonNull(coreIdentityJWT);
             model.put("core_identity_claim_present", coreIdentityClaimPresent);
             model.put("core_identity_claim", coreIdentityJWT);
-
             if (coreIdentityClaimPresent) {
                 model.put("core_identity_claim_signature", validator.isValid(coreIdentityJWT));
             }
+
+            var returnCodeClaim = userInfo.getClaim("https://vocab.account.gov.uk/v1/returnCode");
+            boolean returnCodeClaimPresent = Objects.nonNull(returnCodeClaim);
+            model.put("return_code_claim_present", returnCodeClaimPresent);
+            model.put("return_code_claim", returnCodeClaim);
 
             boolean addressClaimPresent =
                     Objects.nonNull(userInfo.getClaim("https://vocab.account.gov.uk/v1/address"));

--- a/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
+++ b/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
@@ -127,6 +127,14 @@ public class AuthorizeHandler implements Route {
                 claimsSetRequest = claimsSetRequest.add(socialSecurityRecordEntry);
             }
 
+            if (formParameters.containsKey("claims-return-code")) {
+                LOG.info("Return code claim requested");
+                var returnCodeEntry =
+                        new ClaimsSetRequest.Entry(formParameters.get("claims-return-code"))
+                                .withClaimRequirement(ClaimRequirement.ESSENTIAL);
+                claimsSetRequest = claimsSetRequest.add(returnCodeEntry);
+            }
+
             var authRequest =
                     buildAuthorizeRequest(
                             formParameters, vtr, scopes, claimsSetRequest, language, prompt, rpSid);

--- a/src/main/resources/templates/home.mustache
+++ b/src/main/resources/templates/home.mustache
@@ -214,6 +214,12 @@
                                     social security record
                                 </label>
                             </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="claims-return-code" name="claims-return-code" type="checkbox" value="https://vocab.account.gov.uk/v1/returnCode">
+                                <label class="govuk-label govuk-checkboxes__label" for="claims-return-code">
+                                    return code
+                                </label>
+                            </div>
                         </div>
                     </fieldset>
                 </div>

--- a/src/main/resources/templates/userinfo.mustache
+++ b/src/main/resources/templates/userinfo.mustache
@@ -91,7 +91,7 @@
                         <dt class="govuk-summary-list__key">
                             Core Identity Claim Present
                         </dt>
-                        <dd class="govuk-summary-list__value" id="user-info-core-identity-claim">
+                        <dd class="govuk-summary-list__value" id="user-info-core-identity-claim-present">
                             {{core_identity_claim_present}}
                         </dd>
                     </div>
@@ -117,7 +117,7 @@
                         <dt class="govuk-summary-list__key">
                             Address Claim Present
                         </dt>
-                        <dd class="govuk-summary-list__value" id="user-info-address-claim">
+                        <dd class="govuk-summary-list__value" id="user-info-address-claim-present">
                             {{address_claim_present}}
                         </dd>
                     </div>
@@ -125,7 +125,7 @@
                         <dt class="govuk-summary-list__key">
                             Passport Claim Present
                         </dt>
-                        <dd class="govuk-summary-list__value" id="user-info-passport-claim">
+                        <dd class="govuk-summary-list__value" id="user-info-passport-claim-present">
                             {{passport_claim_present}}
                         </dd>
                     </div>
@@ -133,7 +133,7 @@
                         <dt class="govuk-summary-list__key">
                             Driving Permit Claim Present
                         </dt>
-                        <dd class="govuk-summary-list__value" id="user-info-driving-permit-claim">
+                        <dd class="govuk-summary-list__value" id="user-info-driving-permit-claim-present">
                             {{driving_permit_claim_present}}
                         </dd>
                     </div>
@@ -141,7 +141,7 @@
                         <dt class="govuk-summary-list__key">
                             Social Security Record Claim Present
                         </dt>
-                        <dd class="govuk-summary-list__value" id="user-info-social-security-record-claim">
+                        <dd class="govuk-summary-list__value" id="user-info-social-security-record-claim-present">
                             {{social_security_record_claim_present}}
                         </dd>
                     </div>
@@ -149,7 +149,7 @@
                         <dt class="govuk-summary-list__key">
                             Return Code Claim Present
                         </dt>
-                        <dd class="govuk-summary-list__value" id="user-info-return-code-claim">
+                        <dd class="govuk-summary-list__value" id="user-info-return-code-claim-present">
                             {{return_code_claim_present}}
                         </dd>
                     </div>
@@ -165,7 +165,7 @@
                         <dt class="govuk-summary-list__key">
                             ID Token
                         </dt>
-                        <dd class="govuk-summary-list__value" id="user-info-phone-number">
+                        <dd class="govuk-summary-list__value" id="user-info-id-token">
                             {{id_token}}
                         </dd>
                     </div>
@@ -173,7 +173,7 @@
                         <dt class="govuk-summary-list__key">
                             Locale claim
                         </dt>
-                        <dd class="govuk-summary-list__value" id="user-info-locale">
+                        <dd class="govuk-summary-list__value" id="user-info-locale-claim">
                             {{locale_claim}}
                         </dd>
                     </div>

--- a/src/main/resources/templates/userinfo.mustache
+++ b/src/main/resources/templates/userinfo.mustache
@@ -147,6 +147,22 @@
                     </div>
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">
+                            Return Code Claim Present
+                        </dt>
+                        <dd class="govuk-summary-list__value" id="user-info-return-code-claim">
+                            {{return_code_claim_present}}
+                        </dd>
+                    </div>
+                    <div class="govuk-summary-list__row">
+                        <dt class="govuk-summary-list__key">
+                            Return Code Claim
+                        </dt>
+                        <dd class="govuk-summary-list__value" id="user-info-return-code-claim">
+                            {{return_code_claim}}
+                        </dd>
+                    </div>
+                    <div class="govuk-summary-list__row">
+                        <dt class="govuk-summary-list__key">
                             ID Token
                         </dt>
                         <dd class="govuk-summary-list__value" id="user-info-phone-number">


### PR DESCRIPTION
## What?

Add Return Code claim to stub.

## Why?

To test whether the Return Code claim is returned successfully.

## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/3724
