### PR TITLE
ATO-131: Add indentity Inheritance textbox and handler

### DIFF
--- a/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
+++ b/src/main/java/uk/gov/di/handlers/AuthorizeHandler.java
@@ -135,6 +135,22 @@ public class AuthorizeHandler implements Route {
                 claimsSetRequest = claimsSetRequest.add(returnCodeEntry);
             }
 
+            if (formParameters.containsKey("claims-inherited-identity")) {
+                if (!formParameters.get("claims-inherited-identity").trim().isEmpty()) {
+                    LOG.info("Inherited Identity record claim requested");
+                    var inheritedIdentityEntry =
+                            new ClaimsSetRequest.Entry(
+                                            "https://vocab.account.gov.uk/v1/inheritedIdentityJWT")
+                                    .withValues(
+                                            List.of(
+                                                    formParameters.get(
+                                                            "claims-inherited-identity")));
+                    claimsSetRequest = claimsSetRequest.add(inheritedIdentityEntry);
+                } else {
+                    claimsSetRequest.delete("claims-inherited-identity");
+                }
+            }
+
             var authRequest =
                     buildAuthorizeRequest(
                             formParameters, vtr, scopes, claimsSetRequest, language, prompt, rpSid);

--- a/src/main/resources/templates/home.mustache
+++ b/src/main/resources/templates/home.mustache
@@ -221,6 +221,8 @@
                                 </label>
                             </div>
                         </div>
+                        <label class="govuk-label govuk-checkboxes__label" for="claims-inherited-identity">Inherited Identity (jwt):</label>
+                        <textarea class="govuk-textarea" id="claims-inherited-identity" name="claims-inherited-identity" type="text"></textarea>
                     </fieldset>
                 </div>
 


### PR DESCRIPTION
## What?

Added textbox that accepts raw identity inheritance jwt.
Structure of this JWT can be found in draft [ADR](https://github.com/govuk-one-login/architecture/pull/554)

## Why?

Testing identity inheritance

## Related PRs
[ATO-19](https://govukverify.atlassian.net/jira/software/c/projects/ATO/boards/390?selectedIssue=ATO-19)


[ATO-19]: https://govukverify.atlassian.net/browse/ATO-19?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ